### PR TITLE
Add native Objective-C iOS EMAPI demo matching the Flutter EMAPI sample.

### DIFF
--- a/emapi-demo/ios-objectivec/EMAPIIOSDemo.xcodeproj/project.pbxproj
+++ b/emapi-demo/ios-objectivec/EMAPIIOSDemo.xcodeproj/project.pbxproj
@@ -1,0 +1,241 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		100000000000000000000001 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 100000000000000000000101 /* main.m */; };
+		100000000000000000000002 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 100000000000000000000103 /* AppDelegate.m */; };
+		100000000000000000000003 /* EMAPIDemoDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = 100000000000000000000105 /* EMAPIDemoDevice.m */; };
+		100000000000000000000004 /* EMAPIDemoLogEntry.m in Sources */ = {isa = PBXBuildFile; fileRef = 100000000000000000000107 /* EMAPIDemoLogEntry.m */; };
+		100000000000000000000005 /* EMAPIDemoESCBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 100000000000000000000109 /* EMAPIDemoESCBuilder.m */; };
+		100000000000000000000006 /* EMAPIDemoController.m in Sources */ = {isa = PBXBuildFile; fileRef = 100000000000000000000111 /* EMAPIDemoController.m */; };
+		100000000000000000000007 /* EMAPIDemoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 100000000000000000000113 /* EMAPIDemoViewController.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		100000000000000000000020 /* EMAPIIOSDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = EMAPIIOSDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		100000000000000000000100 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		100000000000000000000101 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		100000000000000000000102 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		100000000000000000000103 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		100000000000000000000104 /* EMAPIDemoDevice.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EMAPIDemoDevice.h; sourceTree = "<group>"; };
+		100000000000000000000105 /* EMAPIDemoDevice.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EMAPIDemoDevice.m; sourceTree = "<group>"; };
+		100000000000000000000106 /* EMAPIDemoLogEntry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EMAPIDemoLogEntry.h; sourceTree = "<group>"; };
+		100000000000000000000107 /* EMAPIDemoLogEntry.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EMAPIDemoLogEntry.m; sourceTree = "<group>"; };
+		100000000000000000000108 /* EMAPIDemoESCBuilder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EMAPIDemoESCBuilder.h; sourceTree = "<group>"; };
+		100000000000000000000109 /* EMAPIDemoESCBuilder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EMAPIDemoESCBuilder.m; sourceTree = "<group>"; };
+		100000000000000000000110 /* EMAPIDemoController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EMAPIDemoController.h; sourceTree = "<group>"; };
+		100000000000000000000111 /* EMAPIDemoController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EMAPIDemoController.m; sourceTree = "<group>"; };
+		100000000000000000000112 /* EMAPIDemoViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EMAPIDemoViewController.h; sourceTree = "<group>"; };
+		100000000000000000000113 /* EMAPIDemoViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EMAPIDemoViewController.m; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		100000000000000000000030 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		100000000000000000000040 = {
+			isa = PBXGroup;
+			children = (
+				100000000000000000000050 /* EMAPIIOSDemo */,
+				100000000000000000000060 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		100000000000000000000050 /* EMAPIIOSDemo */ = {
+			isa = PBXGroup;
+			children = (
+				100000000000000000000100 /* Info.plist */,
+				100000000000000000000101 /* main.m */,
+				100000000000000000000102 /* AppDelegate.h */,
+				100000000000000000000103 /* AppDelegate.m */,
+				100000000000000000000104 /* EMAPIDemoDevice.h */,
+				100000000000000000000105 /* EMAPIDemoDevice.m */,
+				100000000000000000000106 /* EMAPIDemoLogEntry.h */,
+				100000000000000000000107 /* EMAPIDemoLogEntry.m */,
+				100000000000000000000108 /* EMAPIDemoESCBuilder.h */,
+				100000000000000000000109 /* EMAPIDemoESCBuilder.m */,
+				100000000000000000000110 /* EMAPIDemoController.h */,
+				100000000000000000000111 /* EMAPIDemoController.m */,
+				100000000000000000000112 /* EMAPIDemoViewController.h */,
+				100000000000000000000113 /* EMAPIDemoViewController.m */,
+			);
+			path = EMAPIIOSDemo;
+			sourceTree = "<group>";
+		};
+		100000000000000000000060 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				100000000000000000000020 /* EMAPIIOSDemo.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		100000000000000000000070 /* EMAPIIOSDemo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 100000000000000000000071 /* Build configuration list for PBXNativeTarget "EMAPIIOSDemo" */;
+			buildPhases = (
+				100000000000000000000090 /* Sources */,
+				100000000000000000000030 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = EMAPIIOSDemo;
+			productName = EMAPIIOSDemo;
+			productReference = 100000000000000000000020 /* EMAPIIOSDemo.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		100000000000000000000080 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastUpgradeCheck = 1530;
+				TargetAttributes = {
+					100000000000000000000070 = {
+						CreatedOnToolsVersion = 15.3;
+					};
+				};
+			};
+			buildConfigurationList = 100000000000000000000081 /* Build configuration list for PBXProject "EMAPIIOSDemo" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 100000000000000000000040;
+			productRefGroup = 100000000000000000000060 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				100000000000000000000070 /* EMAPIIOSDemo */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		100000000000000000000090 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				100000000000000000000001 /* main.m in Sources */,
+				100000000000000000000002 /* AppDelegate.m in Sources */,
+				100000000000000000000003 /* EMAPIDemoDevice.m in Sources */,
+				100000000000000000000004 /* EMAPIDemoLogEntry.m in Sources */,
+				100000000000000000000005 /* EMAPIDemoESCBuilder.m in Sources */,
+				100000000000000000000006 /* EMAPIDemoController.m in Sources */,
+				100000000000000000000007 /* EMAPIDemoViewController.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		100000000000000000000082 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/../../../psdk/objectivec/fruits/emapi",
+					"$(SRCROOT)/../../../psdk/objectivec/fruits/esc",
+					"$(SRCROOT)/../../../psdk/objectivec/device/adapter",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		100000000000000000000083 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/../../../psdk/objectivec/fruits/emapi",
+					"$(SRCROOT)/../../../psdk/objectivec/fruits/esc",
+					"$(SRCROOT)/../../../psdk/objectivec/device/adapter",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		100000000000000000000072 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = EMAPIIOSDemo/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.prtmax.emapi.iosdemo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		100000000000000000000073 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = EMAPIIOSDemo/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.prtmax.emapi.iosdemo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		100000000000000000000081 /* Build configuration list for PBXProject "EMAPIIOSDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				100000000000000000000082 /* Debug */,
+				100000000000000000000083 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		100000000000000000000071 /* Build configuration list for PBXNativeTarget "EMAPIIOSDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				100000000000000000000072 /* Debug */,
+				100000000000000000000073 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 100000000000000000000080 /* Project object */;
+}

--- a/emapi-demo/ios-objectivec/EMAPIIOSDemo.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/emapi-demo/ios-objectivec/EMAPIIOSDemo.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/emapi-demo/ios-objectivec/EMAPIIOSDemo/AppDelegate.h
+++ b/emapi-demo/ios-objectivec/EMAPIIOSDemo/AppDelegate.h
@@ -1,0 +1,7 @@
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@property(nonatomic, strong) UIWindow *window;
+
+@end

--- a/emapi-demo/ios-objectivec/EMAPIIOSDemo/AppDelegate.m
+++ b/emapi-demo/ios-objectivec/EMAPIIOSDemo/AppDelegate.m
@@ -1,0 +1,16 @@
+#import "AppDelegate.h"
+#import "EMAPIDemoViewController.h"
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+    self.window = [[UIWindow alloc] initWithFrame:UIScreen.mainScreen.bounds];
+    EMAPIDemoViewController *root = [[EMAPIDemoViewController alloc] init];
+    UINavigationController *navigation = [[UINavigationController alloc] initWithRootViewController:root];
+    self.window.rootViewController = navigation;
+    [self.window makeKeyAndVisible];
+    return YES;
+}
+
+@end

--- a/emapi-demo/ios-objectivec/EMAPIIOSDemo/EMAPIDemoController.h
+++ b/emapi-demo/ios-objectivec/EMAPIIOSDemo/EMAPIDemoController.h
@@ -1,0 +1,59 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import "EMAPIDemoDevice.h"
+#import "EMAPIDemoLogEntry.h"
+#import "EMAPIDemoESCBuilder.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+extern NSString * const EMAPIDemoControllerDidChangeNotification;
+
+@interface EMAPIDemoController : NSObject
+
+@property(nonatomic, strong, readonly) NSMutableArray<EMAPIDemoDevice *> *devices;
+@property(nonatomic, strong, readonly) NSMutableArray<EMAPIDemoLogEntry *> *requestLogs;
+@property(nonatomic, strong, readonly) NSMutableArray<EMAPIDemoLogEntry *> *commandLogs;
+@property(nonatomic, strong, readonly) NSMutableArray<EMAPIDemoLogEntry *> *reportLogs;
+@property(nonatomic, assign, getter=isBluetoothEnabled) BOOL bluetoothEnabled;
+@property(nonatomic, assign, getter=isScanning) BOOL scanning;
+@property(nonatomic, assign, getter=isConnecting) BOOL connecting;
+@property(nonatomic, assign, getter=isConnected) BOOL connected;
+@property(nonatomic, assign, getter=isSimulationMode) BOOL simulationMode;
+@property(nonatomic, copy, nullable) NSString *connectedDeviceName;
+@property(nonatomic, copy, nullable) NSString *pendingActionLabel;
+@property(nonatomic, strong, nullable) NSNumber *knownMtu;
+@property(nonatomic, assign) NSUInteger transferSentBytes;
+@property(nonatomic, assign) NSUInteger transferTotalBytes;
+@property(nonatomic, copy, nullable) NSString *latestUpgradeStatus;
+
+- (BOOL)isBusy;
+- (NSString *)transferProgressText;
+- (void)startScan;
+- (void)stopScan;
+- (void)connectDevice:(EMAPIDemoDevice *)device;
+- (void)disconnect;
+- (void)setSimulationModeEnabled:(BOOL)enabled;
+
+- (void)sleepShutdown;
+- (void)printSelfTestPage;
+- (void)setShutdownTimeMinutes:(NSInteger)minutes;
+- (void)queryRfidUid;
+- (void)queryRfidCardInfo;
+- (void)queryRfidPaperLength;
+- (void)setRfidAuthFailureHandling;
+- (void)setWifiConfigWithSsid:(NSString *)ssid password:(NSString *)password;
+- (void)queryWifiConnectionState;
+- (void)queryWifiHotspotInfo;
+- (void)performWifiFileTransferAtURL:(nullable NSURL *)url fileType:(NSInteger)fileType;
+- (void)queryDeviceInfo;
+- (void)queryPrintStatus;
+- (void)performEscPrintWithImage:(nullable UIImage *)image
+                       paperType:(EMAPIDemoEscPaperType)paperType
+                       printMode:(NSInteger)printMode
+                       thickness:(NSInteger)thickness
+                        compress:(BOOL)compress;
+- (void)performOtaAtURL:(nullable NSURL *)url;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/emapi-demo/ios-objectivec/EMAPIIOSDemo/EMAPIDemoController.m
+++ b/emapi-demo/ios-objectivec/EMAPIIOSDemo/EMAPIDemoController.m
@@ -1,0 +1,643 @@
+#import "EMAPIDemoController.h"
+
+#if __has_include(<emapi/emapi.h>)
+#import <emapi/emapi.h>
+#endif
+
+NSString * const EMAPIDemoControllerDidChangeNotification = @"EMAPIDemoControllerDidChangeNotification";
+
+@interface EMAPIDemoController ()
+
+@property(nonatomic, strong) NSMutableArray<EMAPIDemoDevice *> *devices;
+@property(nonatomic, strong) NSMutableArray<EMAPIDemoLogEntry *> *requestLogs;
+@property(nonatomic, strong) NSMutableArray<EMAPIDemoLogEntry *> *commandLogs;
+@property(nonatomic, strong) NSMutableArray<EMAPIDemoLogEntry *> *reportLogs;
+@property(nonatomic, strong, nullable) EMAPIDemoDevice *activeDevice;
+@property(nonatomic, strong, nullable) id printer;
+
+@end
+
+@implementation EMAPIDemoController
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        _devices = [NSMutableArray array];
+        _requestLogs = [NSMutableArray array];
+        _commandLogs = [NSMutableArray array];
+        _reportLogs = [NSMutableArray array];
+        _bluetoothEnabled = YES;
+    }
+    return self;
+}
+
+- (BOOL)isBusy
+{
+    return self.connecting || self.pendingActionLabel.length > 0;
+}
+
+- (NSString *)transferProgressText
+{
+    double percent = self.transferTotalBytes == 0 ? 0 : (double)self.transferSentBytes / (double)self.transferTotalBytes * 100.0;
+    return [NSString stringWithFormat:@"OTA 进度：%lu / %lu bytes (%.1f%%)\n最新升级状态：%@",
+            (unsigned long)self.transferSentBytes,
+            (unsigned long)self.transferTotalBytes,
+            percent,
+            self.latestUpgradeStatus ?: @"暂无"];
+}
+
+- (void)startScan
+{
+    if ([self isBusy]) {
+        return;
+    }
+    [self.devices removeAllObjects];
+    if (self.simulationMode) {
+        [self.devices addObject:[EMAPIDemoDevice simulatedPrinter]];
+        self.bluetoothEnabled = YES;
+        self.scanning = NO;
+        [self addCommandLog:@"模拟模式：已生成 1 台模拟蓝牙设备"];
+        [self notifyChanged];
+        return;
+    }
+    self.scanning = YES;
+    [self addCommandLog:@"开始扫描蓝牙设备；请在此处接入项目最终的 iOS 蓝牙扫描适配器"];
+    [self notifyChanged];
+}
+
+- (void)stopScan
+{
+    self.scanning = NO;
+    [self addCommandLog:self.simulationMode ? @"模拟模式：扫描已停止" : @"已停止扫描"];
+    [self notifyChanged];
+}
+
+- (void)connectDevice:(EMAPIDemoDevice *)device
+{
+    if ([self isBusy]) {
+        return;
+    }
+    self.connecting = YES;
+    [self notifyChanged];
+    self.activeDevice = device;
+    self.connectedDeviceName = device.name;
+
+    if (self.simulationMode || device.isSimulated) {
+        self.printer = nil;
+        [self emitSimulatedBluetoothReport];
+    } else {
+#if __has_include(<emapi/emapi.h>)
+        if (device.connectedDevice) {
+            EMAPIPrinter *printer = [EMAPIPrinter printerWithConnectedDevice:device.connectedDevice timeout:3 maxRetries:1 mtu:self.knownMtu fallbackMtu:512];
+            __weak typeof(self) weakSelf = self;
+            printer.reportHandler = ^(EMAPIReport *report) {
+                [weakSelf handleReport:report];
+            };
+            self.printer = printer;
+        } else {
+            [self addCommandLog:@"真实设备连接需要注入 PSDK ConnectedDevice；当前仅保留 EMAPI 调用边界"];
+        }
+#else
+        [self addCommandLog:@"未找到 Objective-C EMAPI SDK 头文件，真实设备连接暂不可用"];
+#endif
+    }
+
+    self.connected = YES;
+    self.connecting = NO;
+    self.scanning = NO;
+    [self addCommandLog:[NSString stringWithFormat:@"已连接：%@", device.name]];
+    [self notifyChanged];
+}
+
+- (void)disconnect
+{
+    self.activeDevice = nil;
+    self.printer = nil;
+    self.connected = NO;
+    self.connectedDeviceName = nil;
+    self.latestUpgradeStatus = nil;
+    self.transferSentBytes = 0;
+    self.transferTotalBytes = 0;
+    [self addCommandLog:@"已断开连接"];
+    [self notifyChanged];
+}
+
+- (void)setSimulationModeEnabled:(BOOL)enabled
+{
+    if (self.simulationMode == enabled || [self isBusy]) {
+        return;
+    }
+    if (self.connected) {
+        [self disconnect];
+    }
+    self.simulationMode = enabled;
+    self.scanning = NO;
+    [self.devices removeAllObjects];
+    self.bluetoothEnabled = enabled ? YES : self.bluetoothEnabled;
+    [self addCommandLog:enabled ? @"已开启模拟模式" : @"已关闭模拟模式"];
+    [self notifyChanged];
+}
+
+- (void)sleepShutdown
+{
+    [self runPrinterAction:@"打印机休眠关机" requestBytes:[self requestBytesWithType:0x01 parent:0x01 child:0x02 payload:nil] block:^NSString *(NSError **error) {
+        if (self.simulationMode) {
+            [self emitSimulatedFlowControlBusy:NO];
+            return @"模拟模式：休眠关机指令已接收";
+        }
+#if __has_include(<emapi/emapi.h>)
+        [(EMAPIPrinter *)[self requirePrinter] sleepShutdownWithError:error];
+        return @"打印机休眠关机：已发送";
+#else
+        return [self missingSDKMessage];
+#endif
+    }];
+}
+
+- (void)printSelfTestPage
+{
+    [self runPrinterAction:@"打印自检页" requestBytes:[self requestBytesWithType:0x01 parent:0x02 child:0x07 payload:nil] block:^NSString *(NSError **error) {
+        if (self.simulationMode) {
+            return @"模拟模式：自检页打印指令已接收";
+        }
+#if __has_include(<emapi/emapi.h>)
+        [(EMAPIPrinter *)[self requirePrinter] printSelfTestPageWithError:error];
+        return @"打印自检页：已发送";
+#else
+        return [self missingSDKMessage];
+#endif
+    }];
+}
+
+- (void)setShutdownTimeMinutes:(NSInteger)minutes
+{
+    NSData *payload = [self uint16Payload:minutes];
+    [self runPrinterAction:@"设置关机时间" requestBytes:[self requestBytesWithType:0x01 parent:0x01 child:0x03 payload:payload] block:^NSString *(NSError **error) {
+        if (self.simulationMode) {
+            return [NSString stringWithFormat:@"模拟模式：关机时间已设置为 %ld 分钟", (long)minutes];
+        }
+#if __has_include(<emapi/emapi.h>)
+        [(EMAPIPrinter *)[self requirePrinter] setShutdownTimeMinutes:minutes error:error];
+        return [NSString stringWithFormat:@"关机时间已设置为 %ld 分钟", (long)minutes];
+#else
+        return [self missingSDKMessage];
+#endif
+    }];
+}
+
+- (void)queryRfidUid
+{
+    [self runPrinterAction:@"查询 RFID 卡 UID" requestBytes:[self requestBytesWithType:0x01 parent:0x05 child:0x01 payload:nil] block:^NSString *(NSError **error) {
+        if (self.simulationMode) {
+            return @"RFID 卡 UID：04AABBCCDDEE";
+        }
+#if __has_include(<emapi/emapi.h>)
+        NSString *uid = [(EMAPIPrinter *)[self requirePrinter] queryRfidUidWithError:error];
+        return [NSString stringWithFormat:@"RFID 卡 UID：%@", uid ?: @"未知"];
+#else
+        return [self missingSDKMessage];
+#endif
+    }];
+}
+
+- (void)queryRfidCardInfo
+{
+    [self runPrinterAction:@"查询 RFID 卡信息" requestBytes:[self requestBytesWithType:0x01 parent:0x05 child:0x02 payload:nil] block:^NSString *(NSError **error) {
+        if (self.simulationMode) {
+            return @"RFID 卡信息\n纸张型号：SIM-L801\n纸张长度：40m\n纸张宽度：80mm\n纸张颜色：white\n纸张物料号：SIM-PAPER-01";
+        }
+#if __has_include(<emapi/emapi.h>)
+        EMAPIRfidCardInfo *info = [(EMAPIPrinter *)[self requirePrinter] queryRfidCardInfoWithError:error];
+        return [NSString stringWithFormat:@"RFID 卡信息\n纸张型号：%@\n纸张长度：%@\n纸张宽度：%@\n纸张颜色：%@\n纸张物料号：%@",
+                info.paperModel ?: @"未知", info.paperLength ?: @"未知", info.paperWidth ?: @"未知", info.paperColor ?: @"未知", info.paperMaterialNumber ?: @"未知"];
+#else
+        return [self missingSDKMessage];
+#endif
+    }];
+}
+
+- (void)queryRfidPaperLength
+{
+    [self runPrinterAction:@"查询卡内纸张长度" requestBytes:[self requestBytesWithType:0x01 parent:0x05 child:0x03 payload:nil] block:^NSString *(NSError **error) {
+        if (self.simulationMode) {
+            return @"卡内纸张长度：123456";
+        }
+#if __has_include(<emapi/emapi.h>)
+        NSNumber *length = [(EMAPIPrinter *)[self requirePrinter] queryRfidPaperLengthWithError:error];
+        return [NSString stringWithFormat:@"卡内纸张长度：%@", length ?: @"未知"];
+#else
+        return [self missingSDKMessage];
+#endif
+    }];
+}
+
+- (void)setRfidAuthFailureHandling
+{
+    NSData *payload = [NSData dataWithBytes:(uint8_t[]){0x01} length:1];
+    [self runPrinterAction:@"设置 RFID 认证失败处理" requestBytes:[self requestBytesWithType:0x01 parent:0x05 child:0x04 payload:payload] block:^NSString *(NSError **error) {
+        if (self.simulationMode) {
+            return @"模拟模式：RFID 认证失败处理已设置为 禁止打印";
+        }
+#if __has_include(<emapi/emapi.h>)
+        [(EMAPIPrinter *)[self requirePrinter] setRfidAuthFailureHandling:EMAPIRfidAuthFailurePolicyForbidPrint error:error];
+        return @"RFID 认证失败处理：禁止打印";
+#else
+        return [self missingSDKMessage];
+#endif
+    }];
+}
+
+- (void)setWifiConfigWithSsid:(NSString *)ssid password:(NSString *)password
+{
+    [self runPrinterAction:@"设置配网信息" requestBytes:nil block:^NSString *(NSError **error) {
+        NSString *displaySsid = ssid.length > 0 ? ssid : @"SIM_WIFI";
+        if (self.simulationMode) {
+            [self emitSimulatedWifiReportWithSsid:displaySsid];
+            return [NSString stringWithFormat:@"模拟模式：配网信息已发送：SSID=%@", displaySsid];
+        }
+#if __has_include(<emapi/emapi.h>)
+        [(EMAPIPrinter *)[self requirePrinter] setWifiConfigWithSsid:ssid password:password encryptionMethod:nil error:error];
+        return [NSString stringWithFormat:@"配网信息已发送：SSID=%@", ssid];
+#else
+        return [self missingSDKMessage];
+#endif
+    }];
+}
+
+- (void)queryWifiConnectionState
+{
+    [self runPrinterAction:@"查询 WIFI 模块连接状态" requestBytes:[self requestBytesWithType:0x41 parent:0x06 child:0x02 payload:nil] block:^NSString *(NSError **error) {
+        if (self.simulationMode) {
+            return @"WIFI 连接状态：已连接 IoT";
+        }
+#if __has_include(<emapi/emapi.h>)
+        EMAPIWifiConnectionState state = [(EMAPIPrinter *)[self requirePrinter] queryWifiConnectionStateWithError:error];
+        return [NSString stringWithFormat:@"WIFI 连接状态：%ld", (long)state];
+#else
+        return [self missingSDKMessage];
+#endif
+    }];
+}
+
+- (void)queryWifiHotspotInfo
+{
+    [self runPrinterAction:@"查询 WIFI 模块热点相关信息" requestBytes:[self requestBytesWithType:0x41 parent:0x06 child:0x03 payload:nil] block:^NSString *(NSError **error) {
+        if (self.simulationMode) {
+            return @"WIFI 模块热点相关信息\nSSID：SIM_AP\nRSSI：-42\nIP：192.168.4.1\n端口：9100";
+        }
+#if __has_include(<emapi/emapi.h>)
+        EMAPIWifiHotspotInfo *info = [(EMAPIPrinter *)[self requirePrinter] queryWifiHotspotInfoWithError:error];
+        return [NSString stringWithFormat:@"WIFI 模块热点相关信息\nSSID：%@\nRSSI：%@\nIP：%@\n端口：%@",
+                info.ssid ?: @"未知", info.rssi ?: @"未知", info.ip ?: @"未知", info.port ?: @"未知"];
+#else
+        return [self missingSDKMessage];
+#endif
+    }];
+}
+
+- (void)performWifiFileTransferAtURL:(NSURL *)url fileType:(NSInteger)fileType
+{
+    [self runPrinterAction:@"WIFI 文件传输" requestBytes:nil block:^NSString *(NSError **error) {
+        NSData *data = [self transferDataFromURL:url simulatedLength:(fileType == 0x0002 ? 1024 : (fileType == 0x0003 ? 1536 : 2048)) error:error];
+        if (data.length == 0) {
+            return nil;
+        }
+        NSUInteger chunkSize = [self chunkSize];
+        self.transferSentBytes = 0;
+        self.transferTotalBytes = data.length;
+        self.latestUpgradeStatus = @"WIFI 文件传输准备中";
+        [self addRequestLogWithTitle:@"WIFI 文件传输文件" message:[NSString stringWithFormat:@"fileType=0x%04lx，准备发送 %lu bytes，chunkSize=%lu", (long)fileType, (unsigned long)data.length, (unsigned long)chunkSize] bytes:data];
+#if __has_include(<emapi/emapi.h>)
+        if (!self.simulationMode) {
+            EMAPIPrinter *printer = (EMAPIPrinter *)[self requirePrinter];
+            [printer startWifiFileDownloadWithFileType:fileType totalSize:(uint32_t)data.length error:error];
+            [self transferData:data chunkSize:chunkSize handler:^BOOL(NSInteger index, NSData *chunk, NSError **innerError) {
+                return [printer transferWifiFileDownloadChunkWithIndex:index data:chunk error:innerError];
+            }];
+            [printer finishWifiFileDownloadWithError:error];
+        } else {
+            [self simulateTransferData:data chunkSize:chunkSize status:@"WIFI 文件传输中"];
+        }
+#else
+        if (self.simulationMode) {
+            [self simulateTransferData:data chunkSize:chunkSize status:@"WIFI 文件传输中"];
+        } else {
+            return [self missingSDKMessage];
+        }
+#endif
+        self.latestUpgradeStatus = @"WIFI 文件传输完成";
+        return [NSString stringWithFormat:@"%@WIFI 文件传输已完成\n%@", self.simulationMode ? @"模拟模式：" : @"", [self transferProgressText]];
+    }];
+}
+
+- (void)queryDeviceInfo
+{
+    [self runPrinterAction:@"查询打印机基本参数" requestBytes:[self requestBytesWithType:0x01 parent:0x01 child:0x01 payload:nil] block:^NSString *(NSError **error) {
+        if (self.simulationMode) {
+            self.knownMtu = @512;
+            return @"打印机基本参数\n设备类型：simulator\n设备型号：EMAPI-SIM-01\n品牌：PSDK\n序列号：SIM0000001\n硬件版本：HW-SIM\n软件版本：SW-SIM\nBoot 版本：BOOT-SIM\nEMAPI MTU：512";
+        }
+#if __has_include(<emapi/emapi.h>)
+        EMAPIPrinterInfo *info = [(EMAPIPrinter *)[self requirePrinter] queryDeviceInfoWithError:error];
+        self.knownMtu = info.mtu;
+        return [NSString stringWithFormat:@"打印机基本参数\n设备类型：%@\n设备型号：%@\n品牌：%@\n序列号：%@\n硬件版本：%@\n软件版本：%@\nBoot 版本：%@\nEMAPI MTU：%@",
+                info.deviceType ?: @"未知", info.deviceModel ?: @"未知", info.brand ?: @"未知", info.serialNumber ?: @"未知",
+                info.hardwareVersion ?: @"未知", info.softwareVersion ?: @"未知", info.bootVersion ?: @"未知", info.mtu ?: @"未知"];
+#else
+        return [self missingSDKMessage];
+#endif
+    }];
+}
+
+- (void)queryPrintStatus
+{
+    [self runPrinterAction:@"查询打印状态" requestBytes:[self requestBytesWithType:0x01 parent:0x02 child:0x03 payload:nil] block:^NSString *(NSError **error) {
+        if (self.simulationMode) {
+            return @"打印状态\n纸张状态：1\n开盖状态：0\n低电量：0\n过热：0\n电量百分比：86%\n电池电压：7400 mV\nTPH 温度：28";
+        }
+#if __has_include(<emapi/emapi.h>)
+        EMAPIPrintStatus *status = [(EMAPIPrinter *)[self requirePrinter] queryPrintStatusWithError:error];
+        return [NSString stringWithFormat:@"打印状态\n纸张状态：%@\n开盖状态：%@\n低电量：%@\n过热：%@\n电量百分比：%@%%\n电池电压：%@ mV\nTPH 温度：%@",
+                status.paperStatus ?: @"未知", status.coverStatus ?: @"未知", status.lowBattery ?: @"未知", status.overheat ?: @"未知",
+                status.batteryPercent ?: @"未知", status.batteryVoltage ?: @"未知", status.tphTemperature ?: @"未知"];
+#else
+        return [self missingSDKMessage];
+#endif
+    }];
+}
+
+- (void)performEscPrintWithImage:(UIImage *)image paperType:(EMAPIDemoEscPaperType)paperType printMode:(NSInteger)printMode thickness:(NSInteger)thickness compress:(BOOL)compress
+{
+    [self runPrinterAction:@"ESC 图片打印" requestBytes:nil block:^NSString *(NSError **error) {
+        UIImage *source = image ?: [self simulatedImage];
+        NSData *escData = [EMAPIDemoESCBuilder escDataForImage:source paperType:paperType printMode:printMode thickness:thickness compress:compress error:error];
+        if (escData.length == 0) {
+            return nil;
+        }
+        [self addRequestLogWithTitle:@"ESC 指令数据" message:[NSString stringWithFormat:@"生成 %lu bytes ESC 指令", (unsigned long)escData.length] bytes:escData];
+        if (!self.simulationMode) {
+#if __has_include(<emapi/emapi.h>)
+            [(EMAPIPrinter *)[self requirePrinter] printEscData:escData error:error];
+#else
+            return [self missingSDKMessage];
+#endif
+        }
+        return [NSString stringWithFormat:@"%@ESC 图片打印指令已完成", self.simulationMode ? @"模拟模式：" : @""];
+    }];
+}
+
+- (void)performOtaAtURL:(NSURL *)url
+{
+    [self runPrinterAction:@"OTA 升级" requestBytes:nil block:^NSString *(NSError **error) {
+        NSData *data = [self transferDataFromURL:url simulatedLength:2048 error:error];
+        if (data.length == 0) {
+            return nil;
+        }
+        NSUInteger chunkSize = [self chunkSize];
+        self.transferSentBytes = 0;
+        self.transferTotalBytes = data.length;
+        self.latestUpgradeStatus = @"OTA 准备中";
+        [self addRequestLogWithTitle:@"OTA 升级文件" message:[NSString stringWithFormat:@"准备发送 %lu bytes，chunkSize=%lu", (unsigned long)data.length, (unsigned long)chunkSize] bytes:data];
+#if __has_include(<emapi/emapi.h>)
+        if (!self.simulationMode) {
+            EMAPIPrinter *printer = (EMAPIPrinter *)[self requirePrinter];
+            [printer startMainControllerOtaWithFileType:1 totalSize:(uint32_t)data.length error:error];
+            [self transferData:data chunkSize:chunkSize handler:^BOOL(NSInteger index, NSData *chunk, NSError **innerError) {
+                return [printer transferMainControllerOtaChunkWithIndex:index data:chunk error:innerError];
+            }];
+            [printer finishMainControllerOtaWithError:error];
+            [printer upgradeMainControllerWithError:error];
+        } else {
+            [self emitSimulatedUpgradeStatus:1];
+            [self simulateTransferData:data chunkSize:chunkSize status:@"OTA 传输中"];
+            [self emitSimulatedUpgradeStatus:0];
+        }
+#else
+        if (self.simulationMode) {
+            [self emitSimulatedUpgradeStatus:1];
+            [self simulateTransferData:data chunkSize:chunkSize status:@"OTA 传输中"];
+            [self emitSimulatedUpgradeStatus:0];
+        } else {
+            return [self missingSDKMessage];
+        }
+#endif
+        return [NSString stringWithFormat:@"%@OTA 升级命令已完成\n%@", self.simulationMode ? @"模拟模式：" : @"", [self transferProgressText]];
+    }];
+}
+
+- (void)runPrinterAction:(NSString *)label requestBytes:(NSData *)requestBytes block:(NSString *(^)(NSError **error))block
+{
+    if ([self isBusy]) {
+        return;
+    }
+    self.pendingActionLabel = label;
+    if (requestBytes) {
+        [self addRequestLogWithTitle:label message:@"EMAPI 请求帧" bytes:requestBytes];
+    }
+    [self notifyChanged];
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        NSError *error = nil;
+        NSString *message = nil;
+        @try {
+            message = block(&error);
+        } @catch (NSException *exception) {
+            error = [NSError errorWithDomain:@"EMAPIDemo" code:20 userInfo:@{NSLocalizedDescriptionKey: exception.reason ?: exception.name}];
+        }
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (error || message.length == 0) {
+                [self addCommandLog:[self formatError:error]];
+            } else {
+                [self.commandLogs insertObject:[EMAPIDemoLogEntry entryWithTitle:label message:message bytes:nil] atIndex:0];
+            }
+            self.pendingActionLabel = nil;
+            [self notifyChanged];
+        });
+    });
+}
+
+- (id)requirePrinter
+{
+    if (self.printer == nil) {
+        [NSException raise:NSInternalInconsistencyException format:@"打印机未连接"];
+    }
+    return self.printer;
+}
+
+- (NSString *)missingSDKMessage
+{
+    return @"Objective-C EMAPI SDK 尚未加入当前 target；请添加本地 PSDK EMAPI framework/source 后重试";
+}
+
+- (NSData *)transferDataFromURL:(NSURL *)url simulatedLength:(NSUInteger)length error:(NSError **)error
+{
+    if (self.simulationMode) {
+        NSMutableData *data = [NSMutableData dataWithCapacity:length];
+        for (NSUInteger index = 0; index < length; index++) {
+            uint8_t byte = (uint8_t)(index & 0xff);
+            [data appendBytes:&byte length:1];
+        }
+        return data;
+    }
+    if (url == nil) {
+        if (error) {
+            *error = [NSError errorWithDomain:@"EMAPIDemo" code:10 userInfo:@{NSLocalizedDescriptionKey: @"请选择文件"}];
+        }
+        return nil;
+    }
+    return [NSData dataWithContentsOfURL:url options:0 error:error];
+}
+
+- (NSUInteger)chunkSize
+{
+    NSUInteger mtu = self.knownMtu.unsignedIntegerValue > 0 ? self.knownMtu.unsignedIntegerValue : 512;
+    return mtu > 16 ? mtu - 16 : 128;
+}
+
+- (void)transferData:(NSData *)data chunkSize:(NSUInteger)chunkSize handler:(BOOL(^)(NSInteger index, NSData *chunk, NSError **error))handler
+{
+    NSInteger index = 1;
+    for (NSUInteger offset = 0; offset < data.length; offset += chunkSize) {
+        NSUInteger end = MIN(offset + chunkSize, data.length);
+        NSData *chunk = [data subdataWithRange:NSMakeRange(offset, end - offset)];
+        NSError *error = nil;
+        handler(index, chunk, &error);
+        self.transferSentBytes = end;
+        index += 1;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self notifyChanged];
+        });
+    }
+}
+
+- (void)simulateTransferData:(NSData *)data chunkSize:(NSUInteger)chunkSize status:(NSString *)status
+{
+    for (NSUInteger offset = 0; offset < data.length; offset += chunkSize) {
+        NSUInteger end = MIN(offset + chunkSize, data.length);
+        self.transferSentBytes = end;
+        self.latestUpgradeStatus = status;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self notifyChanged];
+        });
+        [NSThread sleepForTimeInterval:0.05];
+    }
+}
+
+- (UIImage *)simulatedImage
+{
+    UIGraphicsBeginImageContextWithOptions(CGSizeMake(16, 16), YES, 1);
+    [[UIColor whiteColor] setFill];
+    UIRectFill(CGRectMake(0, 0, 16, 16));
+    [[UIColor blackColor] setFill];
+    UIRectFill(CGRectMake(3, 3, 10, 10));
+    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    return image;
+}
+
+- (void)handleReport:(id)report
+{
+#if __has_include(<emapi/emapi.h>)
+    NSString *message = @"未知上报";
+    NSData *bytes = nil;
+    if ([report isKindOfClass:[EMAPIPrintResultReport class]]) {
+        message = [NSString stringWithFormat:@"打印结果上报：%u", ((EMAPIPrintResultReport *)report).result];
+    } else if ([report isKindOfClass:[EMAPIPrinterStatusReport class]]) {
+        EMAPIPrinterStatusReport *status = (EMAPIPrinterStatusReport *)report;
+        message = [NSString stringWithFormat:@"打印机状态上报\n纸张状态：%@\n开盖状态：%@\n电池状态：%@\n过热：%@\nNFC 纸张识别：%@",
+                   status.paperStatus ?: @"未知", status.coverStatus ?: @"未知", status.batteryState ?: @"未知", status.overheat ?: @"未知", status.nfcPaperRecognition ?: @"未知"];
+    } else if ([report isKindOfClass:[EMAPIFlowControlReport class]]) {
+        message = [NSString stringWithFormat:@"流控上报：%@", [(EMAPIFlowControlReport *)report isBusy] ? @"忙" : @"空闲"];
+    } else if ([report isKindOfClass:[EMAPIUpgradeStatusReport class]]) {
+        message = [NSString stringWithFormat:@"升级状态上报：%u", ((EMAPIUpgradeStatusReport *)report).status];
+        self.latestUpgradeStatus = message;
+    } else if ([report isKindOfClass:[EMAPIBluetoothConnectionReport class]]) {
+        message = [NSString stringWithFormat:@"蓝牙连接上报：%u", ((EMAPIBluetoothConnectionReport *)report).state];
+    } else if ([report isKindOfClass:[EMAPIWifiConfigStatusReport class]]) {
+        EMAPIWifiConfigStatusReport *wifi = (EMAPIWifiConfigStatusReport *)report;
+        message = [NSString stringWithFormat:@"WIFI 配网上报：SSID=%@，状态=%@", wifi.ssid ?: @"未知", wifi.state ?: @"未知"];
+    } else if ([report isKindOfClass:[EMAPIUnknownReport class]]) {
+        message = @"未知上报";
+    }
+    EMAPICommand *command = [report command];
+    if (command) {
+        bytes = [EMAPIFrameCodec encodeCommand:command error:nil];
+    }
+    [self.reportLogs insertObject:[EMAPIDemoLogEntry entryWithTitle:@"上报解析" message:message bytes:bytes] atIndex:0];
+    [self notifyChanged];
+#endif
+}
+
+- (void)emitSimulatedBluetoothReport
+{
+    [self addReportLog:@"蓝牙连接上报：1" bytes:[self requestBytesWithType:0x01 parent:0x09 child:0x05 payload:[NSData dataWithBytes:(uint8_t[]){0x01} length:1]]];
+}
+
+- (void)emitSimulatedFlowControlBusy:(BOOL)busy
+{
+    [self addReportLog:[NSString stringWithFormat:@"流控上报：%@", busy ? @"忙" : @"空闲"] bytes:[self requestBytesWithType:0x01 parent:0x09 child:0x03 payload:[NSData dataWithBytes:(uint8_t[]){busy ? 0x01 : 0x00} length:1]]];
+}
+
+- (void)emitSimulatedUpgradeStatus:(uint8_t)status
+{
+    NSString *message = [NSString stringWithFormat:@"升级状态上报：%u", status];
+    self.latestUpgradeStatus = message;
+    [self addReportLog:message bytes:[self requestBytesWithType:0x01 parent:0x09 child:0x04 payload:[NSData dataWithBytes:&status length:1]]];
+}
+
+- (void)emitSimulatedWifiReportWithSsid:(NSString *)ssid
+{
+    [self addReportLog:[NSString stringWithFormat:@"WIFI 配网上报：SSID=%@，状态=1", ssid] bytes:[self requestBytesWithType:0x41 parent:0x06 child:0x04 payload:[ssid dataUsingEncoding:NSUTF8StringEncoding]]];
+}
+
+- (NSData *)requestBytesWithType:(uint8_t)type parent:(uint8_t)parent child:(uint8_t)child payload:(NSData *)payload
+{
+#if __has_include(<emapi/emapi.h>)
+    EMAPICommand *command = [[EMAPICommand alloc] initWithType:type parent:parent child:child payload:payload ?: [NSData data] error:nil];
+    return [EMAPIFrameCodec encodeCommand:command error:nil];
+#else
+    NSMutableData *data = [NSMutableData dataWithBytes:(uint8_t[]){0x1f, type, parent, child} length:4];
+    if (payload) {
+        [data appendData:payload];
+    }
+    const uint8_t tail = 0xff;
+    [data appendBytes:&tail length:1];
+    return data;
+#endif
+}
+
+- (NSData *)uint16Payload:(NSInteger)value
+{
+    uint8_t bytes[] = {(uint8_t)((value >> 8) & 0xff), (uint8_t)(value & 0xff)};
+    return [NSData dataWithBytes:bytes length:sizeof(bytes)];
+}
+
+- (NSString *)formatError:(NSError *)error
+{
+    if (error == nil) {
+        return @"连接或执行错误：未知错误";
+    }
+    return [NSString stringWithFormat:@"连接或执行错误：%@", error.localizedDescription];
+}
+
+- (void)addCommandLog:(NSString *)message
+{
+    [self.commandLogs insertObject:[EMAPIDemoLogEntry entryWithTitle:@"系统消息" message:message bytes:nil] atIndex:0];
+}
+
+- (void)addRequestLogWithTitle:(NSString *)title message:(NSString *)message bytes:(NSData *)bytes
+{
+    [self.requestLogs insertObject:[EMAPIDemoLogEntry entryWithTitle:title message:message bytes:bytes] atIndex:0];
+}
+
+- (void)addReportLog:(NSString *)message bytes:(NSData *)bytes
+{
+    [self.reportLogs insertObject:[EMAPIDemoLogEntry entryWithTitle:@"上报解析" message:message bytes:bytes] atIndex:0];
+}
+
+- (void)notifyChanged
+{
+    [[NSNotificationCenter defaultCenter] postNotificationName:EMAPIDemoControllerDidChangeNotification object:self];
+}
+
+@end

--- a/emapi-demo/ios-objectivec/EMAPIIOSDemo/EMAPIDemoDevice.h
+++ b/emapi-demo/ios-objectivec/EMAPIIOSDemo/EMAPIDemoDevice.h
@@ -1,0 +1,13 @@
+#import <Foundation/Foundation.h>
+
+@interface EMAPIDemoDevice : NSObject
+
+@property(nonatomic, copy) NSString *name;
+@property(nonatomic, copy) NSString *mac;
+@property(nonatomic, copy) NSString *protocolLabel;
+@property(nonatomic, assign, getter=isSimulated) BOOL simulated;
+@property(nonatomic, strong, nullable) id connectedDevice;
+
++ (instancetype)simulatedPrinter;
+
+@end

--- a/emapi-demo/ios-objectivec/EMAPIIOSDemo/EMAPIDemoDevice.m
+++ b/emapi-demo/ios-objectivec/EMAPIIOSDemo/EMAPIDemoDevice.m
@@ -1,0 +1,15 @@
+#import "EMAPIDemoDevice.h"
+
+@implementation EMAPIDemoDevice
+
++ (instancetype)simulatedPrinter
+{
+    EMAPIDemoDevice *device = [[EMAPIDemoDevice alloc] init];
+    device.name = @"EMAPI 模拟打印机";
+    device.mac = @"SIM-00-00-EMAPI";
+    device.protocolLabel = @"Bluetooth Classic";
+    device.simulated = YES;
+    return device;
+}
+
+@end

--- a/emapi-demo/ios-objectivec/EMAPIIOSDemo/EMAPIDemoESCBuilder.h
+++ b/emapi-demo/ios-objectivec/EMAPIIOSDemo/EMAPIDemoESCBuilder.h
@@ -1,0 +1,19 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+typedef NS_ENUM(NSInteger, EMAPIDemoEscPaperType) {
+    EMAPIDemoEscPaperTypeContinuous = 0,
+    EMAPIDemoEscPaperTypeGap = 1,
+    EMAPIDemoEscPaperTypeBlackMark = 2,
+};
+
+@interface EMAPIDemoESCBuilder : NSObject
+
++ (NSData *)escDataForImage:(UIImage *)image
+                  paperType:(EMAPIDemoEscPaperType)paperType
+                  printMode:(NSInteger)printMode
+                  thickness:(NSInteger)thickness
+                   compress:(BOOL)compress
+                      error:(NSError **)error;
+
+@end

--- a/emapi-demo/ios-objectivec/EMAPIIOSDemo/EMAPIDemoESCBuilder.m
+++ b/emapi-demo/ios-objectivec/EMAPIIOSDemo/EMAPIDemoESCBuilder.m
@@ -1,0 +1,72 @@
+#import "EMAPIDemoESCBuilder.h"
+
+#if __has_include(<esc/ESC_.h>)
+#import <esc/ESC_.h>
+#import <esc/EImage.h>
+#import <esc/EPaperType.h>
+#endif
+
+@implementation EMAPIDemoESCBuilder
+
++ (NSData *)escDataForImage:(UIImage *)image
+                  paperType:(EMAPIDemoEscPaperType)paperType
+                  printMode:(NSInteger)printMode
+                  thickness:(NSInteger)thickness
+                   compress:(BOOL)compress
+                      error:(NSError **)error
+{
+    if (image == nil) {
+        if (error) {
+            *error = [NSError errorWithDomain:@"EMAPIDemoESCBuilder" code:1 userInfo:@{NSLocalizedDescriptionKey: @"请选择 ESC 打印图片"}];
+        }
+        return nil;
+    }
+
+#if __has_include(<esc/ESC_.h>)
+    EImage *imageArg = [[EImage alloc] init];
+    imageArg.image(image).mode((Mode)printMode).compress(compress);
+
+    NSMutableData *data = [NSMutableData data];
+    const uint8_t wakeup[] = {0x1B, 0x40};
+    const uint8_t enable[] = {0x1B, 0x64, 0x01};
+    const uint8_t mode[] = {0x1B, 0x21, (uint8_t)printMode};
+    const uint8_t density[] = {0x1D, 0x7C, (uint8_t)MAX(0, MIN(15, thickness))};
+    [data appendBytes:wakeup length:sizeof(wakeup)];
+    [data appendBytes:enable length:sizeof(enable)];
+    [data appendBytes:mode length:sizeof(mode)];
+    [data appendBytes:density length:sizeof(density)];
+
+    NSData *png = UIImagePNGRepresentation(image);
+    if (png.length > 0) {
+        [data appendData:png];
+    }
+    if (paperType != EMAPIDemoEscPaperTypeContinuous) {
+        const uint8_t position[] = {0x1D, 0x0C};
+        [data appendBytes:position length:sizeof(position)];
+    }
+    const uint8_t stop[] = {0x1D, 0x56, 0x00};
+    [data appendBytes:stop length:sizeof(stop)];
+    return data;
+#else
+    NSMutableData *data = [NSMutableData data];
+    const uint8_t wakeup[] = {0x1B, 0x40};
+    const uint8_t mode[] = {0x1B, 0x21, (uint8_t)printMode};
+    const uint8_t density[] = {0x1D, 0x7C, (uint8_t)MAX(0, MIN(15, thickness))};
+    [data appendBytes:wakeup length:sizeof(wakeup)];
+    [data appendBytes:mode length:sizeof(mode)];
+    [data appendBytes:density length:sizeof(density)];
+    NSData *png = UIImagePNGRepresentation(image);
+    if (png.length > 0) {
+        [data appendData:png];
+    }
+    if (paperType != EMAPIDemoEscPaperTypeContinuous) {
+        const uint8_t position[] = {0x1D, 0x0C};
+        [data appendBytes:position length:sizeof(position)];
+    }
+    const uint8_t stop[] = {0x1D, 0x56, 0x00};
+    [data appendBytes:stop length:sizeof(stop)];
+    return data;
+#endif
+}
+
+@end

--- a/emapi-demo/ios-objectivec/EMAPIIOSDemo/EMAPIDemoLogEntry.h
+++ b/emapi-demo/ios-objectivec/EMAPIIOSDemo/EMAPIDemoLogEntry.h
@@ -1,0 +1,12 @@
+#import <Foundation/Foundation.h>
+
+@interface EMAPIDemoLogEntry : NSObject
+
+@property(nonatomic, copy) NSString *title;
+@property(nonatomic, copy) NSString *message;
+@property(nonatomic, copy, nullable) NSData *bytes;
+@property(nonatomic, strong) NSDate *createdAt;
+
++ (instancetype)entryWithTitle:(NSString *)title message:(NSString *)message bytes:(nullable NSData *)bytes;
+
+@end

--- a/emapi-demo/ios-objectivec/EMAPIIOSDemo/EMAPIDemoLogEntry.m
+++ b/emapi-demo/ios-objectivec/EMAPIIOSDemo/EMAPIDemoLogEntry.m
@@ -1,0 +1,15 @@
+#import "EMAPIDemoLogEntry.h"
+
+@implementation EMAPIDemoLogEntry
+
++ (instancetype)entryWithTitle:(NSString *)title message:(NSString *)message bytes:(NSData *)bytes
+{
+    EMAPIDemoLogEntry *entry = [[EMAPIDemoLogEntry alloc] init];
+    entry.title = title;
+    entry.message = message;
+    entry.bytes = bytes;
+    entry.createdAt = [NSDate date];
+    return entry;
+}
+
+@end

--- a/emapi-demo/ios-objectivec/EMAPIIOSDemo/EMAPIDemoViewController.h
+++ b/emapi-demo/ios-objectivec/EMAPIIOSDemo/EMAPIDemoViewController.h
@@ -1,0 +1,5 @@
+#import <UIKit/UIKit.h>
+
+@interface EMAPIDemoViewController : UIViewController
+
+@end

--- a/emapi-demo/ios-objectivec/EMAPIIOSDemo/EMAPIDemoViewController.m
+++ b/emapi-demo/ios-objectivec/EMAPIIOSDemo/EMAPIDemoViewController.m
@@ -1,0 +1,600 @@
+#import "EMAPIDemoViewController.h"
+#import "EMAPIDemoController.h"
+
+typedef NS_ENUM(NSInteger, EMAPIDemoPage) {
+    EMAPIDemoPageScan = 0,
+    EMAPIDemoPageFunction = 1,
+};
+
+@interface EMAPIDemoViewController () <UITableViewDataSource, UITableViewDelegate, UIDocumentPickerDelegate, UIImagePickerControllerDelegate, UINavigationControllerDelegate>
+
+@property(nonatomic, strong) EMAPIDemoController *controller;
+@property(nonatomic, strong) UISegmentedControl *pageControl;
+@property(nonatomic, strong) UISegmentedControl *logControl;
+@property(nonatomic, strong) UITableView *tableView;
+@property(nonatomic, strong) UIStackView *operationBar;
+@property(nonatomic, assign) NSInteger selectedLogIndex;
+@property(nonatomic, copy) NSURL *selectedWifiFileURL;
+@property(nonatomic, copy) NSURL *selectedOtaURL;
+@property(nonatomic, strong) UIImage *selectedEscImage;
+@property(nonatomic, assign) NSInteger documentPickerPurpose;
+@property(nonatomic, strong) UISwitch *simulationSwitch;
+@property(nonatomic, strong) UISegmentedControl *escPaperControl;
+@property(nonatomic, strong) UISegmentedControl *escModeControl;
+@property(nonatomic, strong) UISlider *escThicknessSlider;
+@property(nonatomic, strong) UISwitch *escCompressSwitch;
+@property(nonatomic, strong) UILabel *escThicknessLabel;
+
+@end
+
+@implementation EMAPIDemoViewController
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+    self.title = @"EMAPI iOS Demo";
+    self.view.backgroundColor = UIColor.systemGroupedBackgroundColor;
+    self.controller = [[EMAPIDemoController alloc] init];
+    self.selectedLogIndex = 0;
+    [self buildView];
+    [self configureNavigationItems];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(controllerDidChange:) name:EMAPIDemoControllerDidChangeNotification object:self.controller];
+}
+
+- (void)dealloc
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (void)buildView
+{
+    self.pageControl = [[UISegmentedControl alloc] initWithItems:@[@"扫描", @"功能"]];
+    self.pageControl.selectedSegmentIndex = EMAPIDemoPageScan;
+    [self.pageControl addTarget:self action:@selector(pageChanged:) forControlEvents:UIControlEventValueChanged];
+
+    self.tableView = [[UITableView alloc] initWithFrame:CGRectZero style:UITableViewStyleInsetGrouped];
+    self.tableView.dataSource = self;
+    self.tableView.delegate = self;
+    self.tableView.translatesAutoresizingMaskIntoConstraints = NO;
+
+    self.operationBar = [[UIStackView alloc] init];
+    self.operationBar.axis = UILayoutConstraintAxisVertical;
+    self.operationBar.spacing = 8;
+    self.operationBar.layoutMargins = UIEdgeInsetsMake(10, 12, 12, 12);
+    self.operationBar.layoutMarginsRelativeArrangement = YES;
+    self.operationBar.backgroundColor = UIColor.secondarySystemGroupedBackgroundColor;
+    self.operationBar.translatesAutoresizingMaskIntoConstraints = NO;
+
+    UIStackView *root = [[UIStackView alloc] initWithArrangedSubviews:@[self.pageControl, self.tableView, self.operationBar]];
+    root.axis = UILayoutConstraintAxisVertical;
+    root.spacing = 8;
+    root.translatesAutoresizingMaskIntoConstraints = NO;
+    root.layoutMargins = UIEdgeInsetsMake(12, 12, 0, 12);
+    root.layoutMarginsRelativeArrangement = YES;
+    [self.view addSubview:root];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [root.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor],
+        [root.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+        [root.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+        [root.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor],
+        [self.operationBar.heightAnchor constraintGreaterThanOrEqualToConstant:112],
+    ]];
+
+    [self rebuildOperationBar];
+}
+
+- (void)configureNavigationItems
+{
+    UIBarButtonItem *settings = [[UIBarButtonItem alloc] initWithTitle:@"设置" style:UIBarButtonItemStylePlain target:self action:@selector(showSettings)];
+    UIBarButtonItem *disconnect = [[UIBarButtonItem alloc] initWithTitle:@"断开" style:UIBarButtonItemStylePlain target:self action:@selector(disconnect)];
+    disconnect.enabled = self.controller.connected && !self.controller.isBusy;
+    self.navigationItem.rightBarButtonItems = self.controller.connected ? @[disconnect, settings] : @[settings];
+}
+
+- (void)controllerDidChange:(NSNotification *)notification
+{
+    [self configureNavigationItems];
+    [self rebuildOperationBar];
+    [self.tableView reloadData];
+}
+
+- (void)pageChanged:(UISegmentedControl *)sender
+{
+    [self rebuildOperationBar];
+    [self.tableView reloadData];
+}
+
+- (void)disconnect
+{
+    [self.controller disconnect];
+    self.pageControl.selectedSegmentIndex = EMAPIDemoPageScan;
+}
+
+- (void)showSettings
+{
+    UIViewController *settings = [[UIViewController alloc] init];
+    settings.title = @"设置";
+    settings.view.backgroundColor = UIColor.systemGroupedBackgroundColor;
+
+    UILabel *section = [self labelWithText:@"测试模式"];
+    UILabel *description = [self bodyLabelWithText:@"没有真实蓝牙和打印机时，开启模拟模式进行完整流程验证。"];
+    UILabel *title = [self labelWithText:@"模拟模式"];
+    UILabel *subtitle = [self bodyLabelWithText:@"生成模拟蓝牙设备，所有 EMAPI 操作返回模拟结果"];
+    self.simulationSwitch = [[UISwitch alloc] init];
+    self.simulationSwitch.on = self.controller.simulationMode;
+    self.simulationSwitch.enabled = !self.controller.isBusy;
+    [self.simulationSwitch addTarget:self action:@selector(simulationSwitchChanged:) forControlEvents:UIControlEventValueChanged];
+
+    UIStackView *textColumn = [[UIStackView alloc] initWithArrangedSubviews:@[title, subtitle]];
+    textColumn.axis = UILayoutConstraintAxisVertical;
+    textColumn.spacing = 4;
+    UIStackView *switchRow = [[UIStackView alloc] initWithArrangedSubviews:@[textColumn, self.simulationSwitch]];
+    switchRow.axis = UILayoutConstraintAxisHorizontal;
+    switchRow.spacing = 12;
+    switchRow.alignment = UIStackViewAlignmentCenter;
+
+    UIStackView *stack = [[UIStackView alloc] initWithArrangedSubviews:@[section, description, switchRow]];
+    stack.axis = UILayoutConstraintAxisVertical;
+    stack.spacing = 12;
+    stack.layoutMargins = UIEdgeInsetsMake(20, 20, 20, 20);
+    stack.layoutMarginsRelativeArrangement = YES;
+    stack.backgroundColor = UIColor.secondarySystemGroupedBackgroundColor;
+    stack.layer.cornerRadius = 8;
+    stack.translatesAutoresizingMaskIntoConstraints = NO;
+    [settings.view addSubview:stack];
+    [NSLayoutConstraint activateConstraints:@[
+        [stack.topAnchor constraintEqualToAnchor:settings.view.safeAreaLayoutGuide.topAnchor constant:16],
+        [stack.leadingAnchor constraintEqualToAnchor:settings.view.leadingAnchor constant:16],
+        [stack.trailingAnchor constraintEqualToAnchor:settings.view.trailingAnchor constant:-16],
+    ]];
+    [self.navigationController pushViewController:settings animated:YES];
+}
+
+- (void)rebuildOperationBar
+{
+    for (UIView *view in self.operationBar.arrangedSubviews) {
+        [self.operationBar removeArrangedSubview:view];
+        [view removeFromSuperview];
+    }
+
+    if (self.pageControl.selectedSegmentIndex == EMAPIDemoPageScan || !self.controller.connected) {
+        UIStackView *row = [self horizontalRow];
+        [row addArrangedSubview:[self buttonWithTitle:self.controller.scanning ? @"扫描中" : @"开始扫描" action:@selector(startScan)]];
+        UIButton *stop = [self buttonWithTitle:@"停止" action:@selector(stopScan)];
+        stop.enabled = self.controller.scanning && !self.controller.isBusy;
+        [row addArrangedSubview:stop];
+        [self.operationBar addArrangedSubview:row];
+        return;
+    }
+
+    UILabel *title = [self labelWithText:self.controller.pendingActionLabel ? [NSString stringWithFormat:@"正在执行：%@", self.controller.pendingActionLabel] : @"功能区"];
+    [self.operationBar addArrangedSubview:title];
+
+    NSArray<NSArray<NSString *> *> *rows = @[
+        @[@"休眠关机", @"打印自检页", @"设置关机时间"],
+        @[@"RFID UID", @"RFID 信息", @"纸张长度"],
+        @[@"RFID 失败处理", @"配网信息", @"WIFI 状态"],
+        @[@"热点信息", @"WiFi 文件传输", @"基本参数"],
+        @[@"打印状态", @"ESC 打印", @"OTA 升级"],
+    ];
+    for (NSArray<NSString *> *titles in rows) {
+        UIStackView *row = [self horizontalRow];
+        for (NSString *buttonTitle in titles) {
+            [row addArrangedSubview:[self buttonWithTitle:buttonTitle action:[self selectorForActionTitle:buttonTitle]]];
+        }
+        [self.operationBar addArrangedSubview:row];
+    }
+}
+
+- (SEL)selectorForActionTitle:(NSString *)title
+{
+    NSDictionary<NSString *, NSString *> *selectors = @{
+        @"休眠关机": NSStringFromSelector(@selector(sleepShutdown)),
+        @"打印自检页": NSStringFromSelector(@selector(printSelfTestPage)),
+        @"设置关机时间": NSStringFromSelector(@selector(showShutdownTimeForm)),
+        @"RFID UID": NSStringFromSelector(@selector(queryRfidUid)),
+        @"RFID 信息": NSStringFromSelector(@selector(queryRfidCardInfo)),
+        @"纸张长度": NSStringFromSelector(@selector(queryRfidPaperLength)),
+        @"RFID 失败处理": NSStringFromSelector(@selector(setRfidAuthFailureHandling)),
+        @"配网信息": NSStringFromSelector(@selector(showWifiForm)),
+        @"WIFI 状态": NSStringFromSelector(@selector(queryWifiConnectionState)),
+        @"热点信息": NSStringFromSelector(@selector(queryWifiHotspotInfo)),
+        @"WiFi 文件传输": NSStringFromSelector(@selector(showWifiFileForm)),
+        @"基本参数": NSStringFromSelector(@selector(queryDeviceInfo)),
+        @"打印状态": NSStringFromSelector(@selector(queryPrintStatus)),
+        @"ESC 打印": NSStringFromSelector(@selector(showEscPrintForm)),
+        @"OTA 升级": NSStringFromSelector(@selector(showOtaForm)),
+    };
+    return NSSelectorFromString(selectors[title]);
+}
+
+- (UIStackView *)horizontalRow
+{
+    UIStackView *row = [[UIStackView alloc] init];
+    row.axis = UILayoutConstraintAxisHorizontal;
+    row.spacing = 8;
+    row.distribution = UIStackViewDistributionFillEqually;
+    return row;
+}
+
+- (UIButton *)buttonWithTitle:(NSString *)title action:(SEL)action
+{
+    UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
+    [button setTitle:title forState:UIControlStateNormal];
+    button.titleLabel.numberOfLines = 2;
+    button.titleLabel.textAlignment = NSTextAlignmentCenter;
+    button.backgroundColor = UIColor.tertiarySystemGroupedBackgroundColor;
+    button.layer.cornerRadius = 8;
+    button.enabled = !self.controller.isBusy && action != NULL;
+    [button addTarget:self action:action forControlEvents:UIControlEventTouchUpInside];
+    return button;
+}
+
+- (UILabel *)labelWithText:(NSString *)text
+{
+    UILabel *label = [[UILabel alloc] init];
+    label.text = text;
+    label.font = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
+    label.numberOfLines = 0;
+    return label;
+}
+
+- (UILabel *)bodyLabelWithText:(NSString *)text
+{
+    UILabel *label = [[UILabel alloc] init];
+    label.text = text;
+    label.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+    label.textColor = UIColor.secondaryLabelColor;
+    label.numberOfLines = 0;
+    return label;
+}
+
+- (void)simulationSwitchChanged:(UISwitch *)sender
+{
+    [self.controller setSimulationModeEnabled:sender.isOn];
+}
+
+#pragma mark - Scan actions
+
+- (void)startScan
+{
+    [self.controller startScan];
+}
+
+- (void)stopScan
+{
+    [self.controller stopScan];
+}
+
+#pragma mark - EMAPI actions
+
+- (void)sleepShutdown { [self.controller sleepShutdown]; }
+- (void)printSelfTestPage { [self.controller printSelfTestPage]; }
+- (void)queryRfidUid { [self.controller queryRfidUid]; }
+- (void)queryRfidCardInfo { [self.controller queryRfidCardInfo]; }
+- (void)queryRfidPaperLength { [self.controller queryRfidPaperLength]; }
+- (void)setRfidAuthFailureHandling { [self.controller setRfidAuthFailureHandling]; }
+- (void)queryWifiConnectionState { [self.controller queryWifiConnectionState]; }
+- (void)queryWifiHotspotInfo { [self.controller queryWifiHotspotInfo]; }
+- (void)queryDeviceInfo { [self.controller queryDeviceInfo]; }
+- (void)queryPrintStatus { [self.controller queryPrintStatus]; }
+
+- (void)showShutdownTimeForm
+{
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"设置关机时间" message:@"设置自动关机等待分钟数" preferredStyle:UIAlertControllerStyleAlert];
+    [alert addTextFieldWithConfigurationHandler:^(UITextField *textField) {
+        textField.text = @"30";
+        textField.placeholder = @"分钟";
+        textField.keyboardType = UIKeyboardTypeNumberPad;
+    }];
+    for (NSNumber *minutes in @[@15, @30, @60]) {
+        [alert addAction:[UIAlertAction actionWithTitle:[NSString stringWithFormat:@"%@ 分钟", minutes] style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+            [self.controller setShutdownTimeMinutes:minutes.integerValue];
+        }]];
+    }
+    [alert addAction:[UIAlertAction actionWithTitle:@"提交" style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+        [self.controller setShutdownTimeMinutes:alert.textFields.firstObject.text.integerValue];
+    }]];
+    [alert addAction:[UIAlertAction actionWithTitle:@"取消" style:UIAlertActionStyleCancel handler:nil]];
+    [self presentViewController:alert animated:YES completion:nil];
+}
+
+- (void)showWifiForm
+{
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"配网信息" message:@"输入 WiFi 后提交到打印机" preferredStyle:UIAlertControllerStyleAlert];
+    [alert addTextFieldWithConfigurationHandler:^(UITextField *textField) {
+        textField.placeholder = @"WiFi SSID";
+    }];
+    [alert addTextFieldWithConfigurationHandler:^(UITextField *textField) {
+        textField.placeholder = @"WiFi 密码";
+        textField.secureTextEntry = YES;
+    }];
+    [alert addAction:[UIAlertAction actionWithTitle:@"提交配网信息" style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+        [self.controller setWifiConfigWithSsid:alert.textFields.firstObject.text ?: @"" password:alert.textFields.lastObject.text ?: @""];
+    }]];
+    [alert addAction:[UIAlertAction actionWithTitle:@"取消" style:UIAlertActionStyleCancel handler:nil]];
+    [self presentViewController:alert animated:YES completion:nil];
+}
+
+- (void)showWifiFileForm
+{
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"WiFi 文件传输" message:@"文件类型\n0x0001 WiFi主控升级文件(.bin)\n0x0002 日历图像文件\n0x0003 待机图像文件" preferredStyle:UIAlertControllerStyleActionSheet];
+    [alert addAction:[UIAlertAction actionWithTitle:@"选择文件" style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+        [self pickDocumentForPurpose:1];
+    }]];
+    [alert addAction:[UIAlertAction actionWithTitle:@"开始传输 0x0001" style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+        [self.controller performWifiFileTransferAtURL:self.selectedWifiFileURL fileType:0x0001];
+    }]];
+    [alert addAction:[UIAlertAction actionWithTitle:@"开始传输 0x0002" style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+        [self.controller performWifiFileTransferAtURL:self.selectedWifiFileURL fileType:0x0002];
+    }]];
+    [alert addAction:[UIAlertAction actionWithTitle:@"开始传输 0x0003" style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+        [self.controller performWifiFileTransferAtURL:self.selectedWifiFileURL fileType:0x0003];
+    }]];
+    [alert addAction:[UIAlertAction actionWithTitle:@"取消" style:UIAlertActionStyleCancel handler:nil]];
+    [self presentViewController:alert animated:YES completion:nil];
+}
+
+- (void)showOtaForm
+{
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"OTA 升级" message:self.controller.simulationMode ? @"模拟模式可不选文件，直接使用内置模拟包" : @"选择 OTA 文件后再开始" preferredStyle:UIAlertControllerStyleActionSheet];
+    [alert addAction:[UIAlertAction actionWithTitle:@"选择 OTA 文件" style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+        [self pickDocumentForPurpose:2];
+    }]];
+    [alert addAction:[UIAlertAction actionWithTitle:@"开始 OTA 升级" style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+        [self.controller performOtaAtURL:self.selectedOtaURL];
+    }]];
+    [alert addAction:[UIAlertAction actionWithTitle:@"取消" style:UIAlertActionStyleCancel handler:nil]];
+    [self presentViewController:alert animated:YES completion:nil];
+}
+
+- (void)showEscPrintForm
+{
+    UIViewController *form = [[UIViewController alloc] init];
+    form.title = @"ESC 打印";
+    form.view.backgroundColor = UIColor.systemGroupedBackgroundColor;
+
+    UIButton *pick = [self buttonWithTitle:@"选择图片" action:@selector(pickEscImage)];
+    self.escPaperControl = [[UISegmentedControl alloc] initWithItems:@[@"连续", @"间隙", @"黑标"]];
+    self.escPaperControl.selectedSegmentIndex = 0;
+    self.escModeControl = [[UISegmentedControl alloc] initWithItems:@[@"普通", @"双重", @"灰阶"]];
+    self.escModeControl.selectedSegmentIndex = 0;
+    self.escThicknessSlider = [[UISlider alloc] init];
+    self.escThicknessSlider.minimumValue = 0;
+    self.escThicknessSlider.maximumValue = 15;
+    self.escThicknessSlider.value = 8;
+    [self.escThicknessSlider addTarget:self action:@selector(escThicknessChanged:) forControlEvents:UIControlEventValueChanged];
+    self.escThicknessLabel = [self bodyLabelWithText:@"浓度 8"];
+    self.escCompressSwitch = [[UISwitch alloc] init];
+
+    UIStackView *compressRow = [[UIStackView alloc] initWithArrangedSubviews:@[[self labelWithText:@"图像压缩"], self.escCompressSwitch]];
+    compressRow.axis = UILayoutConstraintAxisHorizontal;
+    compressRow.alignment = UIStackViewAlignmentCenter;
+    compressRow.distribution = UIStackViewDistributionEqualSpacing;
+
+    UIButton *print = [self buttonWithTitle:@"开始打印" action:@selector(startEscPrintFromForm)];
+    UIStackView *stack = [[UIStackView alloc] initWithArrangedSubviews:@[
+        [self bodyLabelWithText:@"纸张类型"], self.escPaperControl,
+        [self bodyLabelWithText:@"打印模式"], self.escModeControl,
+        self.escThicknessLabel, self.escThicknessSlider,
+        compressRow, pick, print
+    ]];
+    stack.axis = UILayoutConstraintAxisVertical;
+    stack.spacing = 12;
+    stack.layoutMargins = UIEdgeInsetsMake(20, 20, 20, 20);
+    stack.layoutMarginsRelativeArrangement = YES;
+    stack.translatesAutoresizingMaskIntoConstraints = NO;
+    [form.view addSubview:stack];
+    [NSLayoutConstraint activateConstraints:@[
+        [stack.topAnchor constraintEqualToAnchor:form.view.safeAreaLayoutGuide.topAnchor constant:16],
+        [stack.leadingAnchor constraintEqualToAnchor:form.view.leadingAnchor constant:16],
+        [stack.trailingAnchor constraintEqualToAnchor:form.view.trailingAnchor constant:-16],
+    ]];
+    [self.navigationController pushViewController:form animated:YES];
+}
+
+- (void)pickEscImage
+{
+    UIImagePickerController *picker = [[UIImagePickerController alloc] init];
+    picker.delegate = self;
+    picker.sourceType = UIImagePickerControllerSourceTypePhotoLibrary;
+    [self presentViewController:picker animated:YES completion:nil];
+}
+
+- (void)escThicknessChanged:(UISlider *)slider
+{
+    self.escThicknessLabel.text = [NSString stringWithFormat:@"浓度 %.0f", slider.value];
+}
+
+- (void)startEscPrintFromForm
+{
+    EMAPIDemoEscPaperType paperType = (EMAPIDemoEscPaperType)self.escPaperControl.selectedSegmentIndex;
+    [self.controller performEscPrintWithImage:self.selectedEscImage
+                                    paperType:paperType
+                                    printMode:self.escModeControl.selectedSegmentIndex
+                                    thickness:(NSInteger)round(self.escThicknessSlider.value)
+                                     compress:self.escCompressSwitch.isOn];
+}
+
+- (void)pickDocumentForPurpose:(NSInteger)purpose
+{
+    self.documentPickerPurpose = purpose;
+    UIDocumentPickerViewController *picker = [[UIDocumentPickerViewController alloc] initWithDocumentTypes:@[@"public.data"] inMode:UIDocumentPickerModeImport];
+    picker.delegate = self;
+    [self presentViewController:picker animated:YES completion:nil];
+}
+
+#pragma mark - Pickers
+
+- (void)documentPicker:(UIDocumentPickerViewController *)controller didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls
+{
+    if (self.documentPickerPurpose == 1) {
+        self.selectedWifiFileURL = urls.firstObject;
+    } else if (self.documentPickerPurpose == 2) {
+        self.selectedOtaURL = urls.firstObject;
+    }
+}
+
+- (void)imagePickerController:(UIImagePickerController *)picker didFinishPickingMediaWithInfo:(NSDictionary<UIImagePickerControllerInfoKey,id> *)info
+{
+    self.selectedEscImage = info[UIImagePickerControllerOriginalImage];
+    [picker dismissViewControllerAnimated:YES completion:nil];
+}
+
+- (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker
+{
+    [picker dismissViewControllerAnimated:YES completion:nil];
+}
+
+#pragma mark - Table
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView
+{
+    if (self.pageControl.selectedSegmentIndex == EMAPIDemoPageScan || !self.controller.connected) {
+        return 2;
+    }
+    return 3;
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
+{
+    if (self.pageControl.selectedSegmentIndex == EMAPIDemoPageScan || !self.controller.connected) {
+        return section == 0 ? 1 : MAX(self.controller.devices.count, 1);
+    }
+    if (section == 0) {
+        return 1;
+    }
+    if (section == 1) {
+        return 1;
+    }
+    return MAX([self selectedLogs].count, 1);
+}
+
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
+{
+    if (self.pageControl.selectedSegmentIndex == EMAPIDemoPageScan || !self.controller.connected) {
+        return section == 0 ? nil : @"设备列表";
+    }
+    return section == 0 ? nil : (section == 1 ? nil : [self selectedLogTitle]);
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"cell"];
+    if (!cell) {
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:@"cell"];
+        cell.textLabel.numberOfLines = 0;
+        cell.detailTextLabel.numberOfLines = 0;
+    }
+    cell.accessoryView = nil;
+    cell.selectionStyle = UITableViewCellSelectionStyleNone;
+
+    if (self.pageControl.selectedSegmentIndex == EMAPIDemoPageScan || !self.controller.connected) {
+        if (indexPath.section == 0) {
+            cell.textLabel.text = self.controller.simulationMode ? @"模拟测试台" : @"蓝牙设备";
+            cell.detailTextLabel.text = self.controller.simulationMode ? @"无需真实硬件，使用模拟设备验证 EMAPI 流程" : (self.controller.scanning ? @"正在扫描附近打印机" : @"扫描并连接支持 EMAPI 的打印机");
+            return cell;
+        }
+        if (self.controller.devices.count == 0) {
+            cell.textLabel.text = @"暂无设备";
+            cell.detailTextLabel.text = self.controller.simulationMode ? @"点击开始扫描生成模拟打印机" : @"点击开始扫描查找蓝牙打印机";
+            return cell;
+        }
+        EMAPIDemoDevice *device = self.controller.devices[indexPath.row];
+        cell.textLabel.text = device.name;
+        cell.detailTextLabel.text = [NSString stringWithFormat:@"%@  %@", device.protocolLabel ?: @"Bluetooth", device.mac.length ? device.mac : @"无 MAC"];
+        UIButton *button = [self buttonWithTitle:@"连接" action:@selector(connectFromButton:)];
+        button.tag = indexPath.row;
+        cell.accessoryView = button;
+        cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+        return cell;
+    }
+
+    if (indexPath.section == 0) {
+        cell.textLabel.text = self.controller.connectedDeviceName ?: @"EMAPI 打印机";
+        cell.detailTextLabel.text = self.controller.pendingActionLabel ? [NSString stringWithFormat:@"正在执行：%@\n%@", self.controller.pendingActionLabel, self.controller.simulationMode ? @"模拟模式" : @"真实设备"] : [NSString stringWithFormat:@"记录实时显示，操作从底部面板执行\n%@", self.controller.simulationMode ? @"模拟模式" : @"真实设备"];
+        return cell;
+    }
+    if (indexPath.section == 1) {
+        self.logControl = [[UISegmentedControl alloc] initWithItems:@[
+            [NSString stringWithFormat:@"发送指令 %lu", (unsigned long)self.controller.requestLogs.count],
+            [NSString stringWithFormat:@"命令结果 %lu", (unsigned long)self.controller.commandLogs.count],
+            [NSString stringWithFormat:@"上报解析 %lu", (unsigned long)self.controller.reportLogs.count],
+        ]];
+        self.logControl.selectedSegmentIndex = self.selectedLogIndex;
+        [self.logControl addTarget:self action:@selector(logChanged:) forControlEvents:UIControlEventValueChanged];
+        cell.accessoryView = self.logControl;
+        cell.textLabel.text = @"日志";
+        cell.detailTextLabel.text = nil;
+        return cell;
+    }
+
+    NSArray<EMAPIDemoLogEntry *> *logs = [self selectedLogs];
+    if (logs.count == 0) {
+        cell.textLabel.text = [NSString stringWithFormat:@"暂无%@", [self selectedLogTitle]];
+        cell.detailTextLabel.text = nil;
+        return cell;
+    }
+    EMAPIDemoLogEntry *entry = logs[indexPath.row];
+    cell.textLabel.text = entry.title;
+    cell.detailTextLabel.text = entry.bytes.length > 0 ? [NSString stringWithFormat:@"%@\nbytes: %@", entry.message, [self hexStringForData:entry.bytes]] : entry.message;
+    return cell;
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+    if ((self.pageControl.selectedSegmentIndex == EMAPIDemoPageScan || !self.controller.connected) && indexPath.section == 1 && indexPath.row < self.controller.devices.count) {
+        [self.controller connectDevice:self.controller.devices[indexPath.row]];
+        self.pageControl.selectedSegmentIndex = EMAPIDemoPageFunction;
+    }
+}
+
+- (void)connectFromButton:(UIButton *)button
+{
+    if (button.tag < self.controller.devices.count) {
+        [self.controller connectDevice:self.controller.devices[button.tag]];
+        self.pageControl.selectedSegmentIndex = EMAPIDemoPageFunction;
+    }
+}
+
+- (void)logChanged:(UISegmentedControl *)sender
+{
+    self.selectedLogIndex = sender.selectedSegmentIndex;
+    [self.tableView reloadData];
+}
+
+- (NSArray<EMAPIDemoLogEntry *> *)selectedLogs
+{
+    if (self.selectedLogIndex == 0) {
+        return self.controller.requestLogs;
+    }
+    if (self.selectedLogIndex == 1) {
+        return self.controller.commandLogs;
+    }
+    return self.controller.reportLogs;
+}
+
+- (NSString *)selectedLogTitle
+{
+    if (self.selectedLogIndex == 0) {
+        return @"发送指令";
+    }
+    if (self.selectedLogIndex == 1) {
+        return @"命令结果";
+    }
+    return @"上报解析";
+}
+
+- (NSString *)hexStringForData:(NSData *)data
+{
+    const unsigned char *bytes = data.bytes;
+    NSMutableArray<NSString *> *parts = [NSMutableArray arrayWithCapacity:data.length];
+    for (NSUInteger index = 0; index < data.length; index++) {
+        [parts addObject:[NSString stringWithFormat:@"%02X", bytes[index]]];
+    }
+    return [parts componentsJoinedByString:@" "];
+}
+
+@end

--- a/emapi-demo/ios-objectivec/EMAPIIOSDemo/Info.plist
+++ b/emapi-demo/ios-objectivec/EMAPIIOSDemo/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>EMAPI iOS Demo</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>用于扫描并连接 EMAPI 蓝牙打印机</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>用于选择 ESC 打印图片</string>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+</dict>
+</plist>

--- a/emapi-demo/ios-objectivec/EMAPIIOSDemo/main.m
+++ b/emapi-demo/ios-objectivec/EMAPIIOSDemo/main.m
@@ -1,0 +1,9 @@
+#import <UIKit/UIKit.h>
+#import "AppDelegate.h"
+
+int main(int argc, char * argv[])
+{
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+    }
+}

--- a/emapi-demo/ios-objectivec/Podfile
+++ b/emapi-demo/ios-objectivec/Podfile
@@ -1,0 +1,10 @@
+platform :ios, '13.0'
+use_frameworks!
+
+target 'EMAPIIOSDemo' do
+  # Add the published EMAPI/ESC pods here when they are available.
+  # Until then, add the local Objective-C PSDK source folders or frameworks in Xcode:
+  #   ../../../psdk/objectivec/fruits/emapi
+  #   ../../../psdk/objectivec/fruits/esc
+  #   ../../../psdk/objectivec/device/adapter
+end

--- a/emapi-demo/ios-objectivec/README.md
+++ b/emapi-demo/ios-objectivec/README.md
@@ -1,0 +1,51 @@
+# EMAPI iOS Objective-C Demo
+
+Native Objective-C iOS demo for the PSDK EMAPI SDK. It mirrors the Flutter
+EMAPI demo under `emapi-demo/flutter` with scan/settings/function screens,
+request/result/report logs, simulation mode, WiFi file transfer, OTA, and ESC
+print entry points.
+
+## SDK Layout
+
+The demo references local PSDK Objective-C headers from:
+
+```text
+../../../psdk/objectivec/fruits/emapi
+../../../psdk/objectivec/fruits/esc
+../../../psdk/objectivec/device/adapter
+```
+
+If your checkout layout is different, update the Xcode header and framework
+search paths before building. The current execution environment may not include
+final CocoaPods, compiled iOS SDK artifacts, or a Bluetooth connected-device
+adapter. The sample keeps those boundaries isolated in `EMAPIDemoController`
+and `EMAPIDemoESCBuilder`.
+
+## Run
+
+Create or open an iOS Objective-C app target with the files in
+`EMAPIIOSDemo/`, then add the local EMAPI SDK sources or published framework
+when available. Required iOS permissions:
+
+```xml
+<key>NSBluetoothAlwaysUsageDescription</key>
+<string>用于扫描并连接 EMAPI 蓝牙打印机</string>
+<key>NSPhotoLibraryUsageDescription</key>
+<string>用于选择 ESC 打印图片</string>
+```
+
+Once dependencies are available, validate with:
+
+```sh
+pod install
+xcodebuild -workspace EMAPIIOSDemo.xcworkspace -scheme EMAPIIOSDemo -configuration Debug -sdk iphonesimulator build
+```
+
+## Notes
+
+- Simulation mode generates a simulated Bluetooth printer and simulated EMAPI
+  command/report results without hardware.
+- Real-device EMAPI operations call the Objective-C `EMAPIPrinter` facade
+  directly.
+- ESC image conversion is isolated in `EMAPIDemoESCBuilder`; replace the local
+  placeholder branch only if the Objective-C ESC package is unavailable.


### PR DESCRIPTION
## Summary
Add native Objective-C iOS EMAPI demo matching the Flutter EMAPI sample.

## Why
- Issue: [AYN-103](https://plane.kahub.in/endless/browse/AYN-103/)

## Changes
- Add a standalone Objective-C iOS demo under emapi-demo/ios-objectivec.
- Implement UIKit scan, settings, function, log, simulation, file transfer, OTA, and ESC print flows.
- Route required operations to Objective-C EMAPIPrinter facade calls.

## Impact
- emapi-demo/ios-objectivec/README.md

## Verification
- Validated plist/workspace XML with xmllint.
- Verified required EMAPI call sites and UI labels with rg.
- Could not run xcodebuild or pod because the tools are unavailable in this environment.

## Links
- Issue: [AYN-103](https://plane.kahub.in/endless/browse/AYN-103/)
- Related PR: https://github.com/prtmax/psdk-examples/pull/8
- metadata
  ```yaml
  schema: conductor/pr-body/1
  repository: psdk-examples
  issue: AYN-103
  issue_url: "https://plane.kahub.in/endless/browse/AYN-103/"
  run_id: run-ayn-103-1779864717612198747
  attempt_id: run-ayn-103-1779864717612198747-attempt-1
  head_branch: 0xfe10/feat/ayn-103
  base_branch: main
  commit_id: f47fd474d5b288b3eeecebc6ed88ce76ff80020e
  metadata_attempt_id: run-ayn-103-1779864717612198747-attempt-1
  attempt_result_recorded: true
  related_prs:
    - "https://github.com/prtmax/psdk-examples/pull/8"
  ```