### PR TITLE
Add a native Java Android EMAPI demo matching the Flutter EMAPI flow.

### DIFF
--- a/android-native-java/emapi-android-demo/app/build.gradle
+++ b/android-native-java/emapi-android-demo/app/build.gradle
@@ -1,0 +1,41 @@
+plugins {
+    id 'com.android.application'
+}
+
+android {
+    compileSdk 32
+
+    defaultConfig {
+        applicationId "com.printer.psdk.examples.emapi"
+        minSdk 21
+        targetSdk 32
+        versionCode 1
+        versionName "1.0"
+
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    sourceSets {
+        main {
+            java.srcDirs += '../../../../../../psdk/java/fruits/emapi/src/main/java'
+        }
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+}
+
+dependencies {
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+}

--- a/android-native-java/emapi-android-demo/app/proguard-rules.pro
+++ b/android-native-java/emapi-android-demo/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Keep the example unminified by default.

--- a/android-native-java/emapi-android-demo/app/src/main/AndroidManifest.xml
+++ b/android-native-java/emapi-android-demo/app/src/main/AndroidManifest.xml
@@ -1,0 +1,22 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+
+    <application
+        android:allowBackup="true"
+        android:label="@string/app_name"
+        android:theme="@style/AppTheme">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/android-native-java/emapi-android-demo/app/src/main/java/com/printer/psdk/examples/emapi/BluetoothEmapiConnection.java
+++ b/android-native-java/emapi-android-demo/app/src/main/java/com/printer/psdk/examples/emapi/BluetoothEmapiConnection.java
@@ -1,0 +1,62 @@
+package com.printer.psdk.examples.emapi;
+
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothSocket;
+
+import com.printer.psdk.emapi.EmapiConnection;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.UUID;
+
+final class BluetoothEmapiConnection implements EmapiConnection {
+    private static final UUID SPP_UUID = UUID.fromString("00001101-0000-1000-8000-00805F9B34FB");
+
+    private final BluetoothSocket socket;
+    private final InputStream input;
+    private final OutputStream output;
+
+    BluetoothEmapiConnection(BluetoothDevice device) throws IOException {
+        socket = device.createRfcommSocketToServiceRecord(SPP_UUID);
+        socket.connect();
+        input = socket.getInputStream();
+        output = socket.getOutputStream();
+    }
+
+    @Override
+    public void write(byte[] data) throws IOException {
+        output.write(data);
+        output.flush();
+    }
+
+    @Override
+    public byte[] read(int timeoutMs) throws IOException {
+        long deadline = System.currentTimeMillis() + Math.max(timeoutMs, 1);
+        while (input.available() == 0 && System.currentTimeMillis() < deadline) {
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted while waiting for EMAPI data", e);
+            }
+        }
+        int available = input.available();
+        if (available <= 0) {
+            return new byte[0];
+        }
+        byte[] buffer = new byte[Math.min(available, 4096)];
+        int count = input.read(buffer);
+        if (count <= 0) {
+            return new byte[0];
+        }
+        byte[] result = new byte[count];
+        System.arraycopy(buffer, 0, result, 0, count);
+        return result;
+    }
+
+    @Override
+    public void close() throws IOException {
+        socket.close();
+    }
+}

--- a/android-native-java/emapi-android-demo/app/src/main/java/com/printer/psdk/examples/emapi/DeviceModel.java
+++ b/android-native-java/emapi-android-demo/app/src/main/java/com/printer/psdk/examples/emapi/DeviceModel.java
@@ -1,0 +1,15 @@
+package com.printer.psdk.examples.emapi;
+
+final class DeviceModel {
+    final String name;
+    final String address;
+    final String protocol;
+    final boolean simulated;
+
+    DeviceModel(String name, String address, String protocol, boolean simulated) {
+        this.name = name == null || name.length() == 0 ? "EMAPI Printer" : name;
+        this.address = address == null ? "" : address;
+        this.protocol = protocol == null ? "Bluetooth" : protocol;
+        this.simulated = simulated;
+    }
+}

--- a/android-native-java/emapi-android-demo/app/src/main/java/com/printer/psdk/examples/emapi/EmapiDemoController.java
+++ b/android-native-java/emapi-android-demo/app/src/main/java/com/printer/psdk/examples/emapi/EmapiDemoController.java
@@ -1,0 +1,695 @@
+package com.printer.psdk.examples.emapi;
+
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Handler;
+import android.os.Looper;
+
+import com.printer.psdk.emapi.EmapiBluetoothConnectionReport;
+import com.printer.psdk.emapi.EmapiCommand;
+import com.printer.psdk.emapi.EmapiFlowControlReport;
+import com.printer.psdk.emapi.EmapiPayload;
+import com.printer.psdk.emapi.EmapiPrintResultReport;
+import com.printer.psdk.emapi.EmapiPrintStatus;
+import com.printer.psdk.emapi.EmapiPrinter;
+import com.printer.psdk.emapi.EmapiPrinterInfo;
+import com.printer.psdk.emapi.EmapiPrinterStatusReport;
+import com.printer.psdk.emapi.EmapiReport;
+import com.printer.psdk.emapi.EmapiRfidAuthFailurePolicy;
+import com.printer.psdk.emapi.EmapiRfidCardInfo;
+import com.printer.psdk.emapi.EmapiUnknownReport;
+import com.printer.psdk.emapi.EmapiUpgradeStatusReport;
+import com.printer.psdk.emapi.EmapiWifiConfigStatusReport;
+import com.printer.psdk.emapi.EmapiWifiConnectionState;
+import com.printer.psdk.emapi.EmapiWifiHotspotInfo;
+import com.printer.psdk.emapi.protocol.EmapiConstants;
+import com.printer.psdk.emapi.protocol.FrameCodec;
+import com.printer.psdk.emapi.protocol.Tlv;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+final class EmapiDemoController {
+    interface Listener {
+        void onChanged();
+    }
+
+    final List<DeviceModel> devices = new ArrayList<DeviceModel>();
+    final List<LogEntry> requestLogs = new ArrayList<LogEntry>();
+    final List<LogEntry> commandLogs = new ArrayList<LogEntry>();
+    final List<LogEntry> reportLogs = new ArrayList<LogEntry>();
+
+    boolean bluetoothEnabled;
+    boolean scanning;
+    boolean connecting;
+    boolean connected;
+    boolean simulationMode;
+    String connectedDeviceName;
+    String pendingActionLabel;
+    int knownMtu = 512;
+    int transferSentBytes;
+    int transferTotalBytes;
+    String latestTransferStatus;
+
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
+    private final ExecutorService executor = Executors.newFixedThreadPool(2);
+    private final Listener listener;
+    private BluetoothAdapter bluetoothAdapter;
+    private BroadcastReceiver scanReceiver;
+    private TracingEmapiConnection tracingConnection;
+    private EmapiPrinter printer;
+    private volatile boolean reportLoopRunning;
+
+    EmapiDemoController(Listener listener) {
+        this.listener = listener;
+    }
+
+    boolean busy() {
+        return connecting || pendingActionLabel != null;
+    }
+
+    String transferProgress() {
+        if (transferTotalBytes <= 0) {
+            return latestTransferStatus == null ? "未开始" : latestTransferStatus;
+        }
+        String status = latestTransferStatus == null ? "" : latestTransferStatus + "\n";
+        return status + transferSentBytes + " / " + transferTotalBytes + " bytes";
+    }
+
+    void init(Context context) {
+        bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
+        bluetoothEnabled = bluetoothAdapter != null && bluetoothAdapter.isEnabled();
+        notifyChanged();
+    }
+
+    void startScan(final Context context) {
+        if (simulationMode) {
+            devices.clear();
+            devices.add(new DeviceModel("EMAPI 模拟打印机", "SIM-00-00-EMAPI", "Bluetooth Classic", true));
+            scanning = false;
+            bluetoothEnabled = true;
+            addCommandLog("模拟模式：已生成 1 台模拟蓝牙设备");
+            notifyChanged();
+            return;
+        }
+        devices.clear();
+        bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
+        bluetoothEnabled = bluetoothAdapter != null && bluetoothAdapter.isEnabled();
+        if (bluetoothAdapter == null || !bluetoothEnabled) {
+            addCommandLog("蓝牙不可用或未开启");
+            notifyChanged();
+            return;
+        }
+        addBondedDevices();
+        registerScanReceiver(context.getApplicationContext());
+        scanning = true;
+        try {
+            bluetoothAdapter.startDiscovery();
+            addCommandLog("开始扫描蓝牙设备");
+        } catch (SecurityException error) {
+            scanning = false;
+            addCommandLog("扫描失败：" + error.getMessage());
+        }
+        notifyChanged();
+    }
+
+    void stopScan(Context context) {
+        if (bluetoothAdapter != null) {
+            try {
+                bluetoothAdapter.cancelDiscovery();
+            } catch (SecurityException ignored) {
+            }
+        }
+        unregisterScanReceiver(context.getApplicationContext());
+        scanning = false;
+        addCommandLog(simulationMode ? "模拟模式：扫描已停止" : "已停止扫描");
+        notifyChanged();
+    }
+
+    void connect(final DeviceModel device) {
+        if (busy()) {
+            return;
+        }
+        connecting = true;
+        notifyChanged();
+        executor.execute(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    if (simulationMode || device.simulated) {
+                        emitSimulatedReport(new EmapiBluetoothConnectionReport(reportCommand(EmapiConstants.CHILD_REPORT_BLUETOOTH_CONNECTION), 1));
+                    } else {
+                        BluetoothDevice bluetoothDevice = bluetoothAdapter.getRemoteDevice(device.address);
+                        tracingConnection = new TracingEmapiConnection(new BluetoothEmapiConnection(bluetoothDevice));
+                        printer = EmapiPrinter.builder().connection(tracingConnection).fallbackMtu(512).build();
+                        startReportLoop();
+                    }
+                    connected = true;
+                    connectedDeviceName = device.name;
+                    addCommandLog("已连接：" + device.name);
+                } catch (Exception error) {
+                    addCommandLog("连接失败：" + formatError(error));
+                } finally {
+                    connecting = false;
+                    scanning = false;
+                    notifyChanged();
+                }
+            }
+        });
+    }
+
+    void disconnect() {
+        reportLoopRunning = false;
+        try {
+            if (printer != null) {
+                printer.close();
+            }
+        } catch (Exception ignored) {
+        }
+        tracingConnection = null;
+        printer = null;
+        connected = false;
+        connectedDeviceName = null;
+        latestTransferStatus = null;
+        addCommandLog("已断开连接");
+        notifyChanged();
+    }
+
+    void setSimulationMode(boolean enabled) {
+        if (simulationMode == enabled) {
+            return;
+        }
+        if (connected) {
+            disconnect();
+        }
+        simulationMode = enabled;
+        devices.clear();
+        scanning = false;
+        if (enabled) {
+            bluetoothEnabled = true;
+        } else {
+            bluetoothEnabled = bluetoothAdapter != null && bluetoothAdapter.isEnabled();
+        }
+        addCommandLog(enabled ? "已开启模拟模式" : "已关闭模拟模式");
+        notifyChanged();
+    }
+
+    void sleepShutdown() {
+        runPrinterAction("打印机休眠关机", request(EmapiConstants.PARENT_SYSTEM, EmapiConstants.CHILD_SYSTEM_SLEEP_SHUTDOWN), new PrinterCallable() {
+            @Override
+            public String call() throws Exception {
+                if (simulationMode) {
+                    emitSimulatedReport(new EmapiFlowControlReport(reportCommand(EmapiConstants.CHILD_REPORT_FLOW_CONTROL), 0));
+                    return "模拟模式：休眠关机指令已接收";
+                }
+                requirePrinter().sleepShutdown();
+                return "打印机休眠关机：已发送";
+            }
+        });
+    }
+
+    void printSelfTestPage() {
+        runPrinterAction("打印自检页", request(EmapiConstants.PARENT_PRINTER, EmapiConstants.CHILD_PRINTER_SELF_TEST_PAGE), new PrinterCallable() {
+            @Override
+            public String call() throws Exception {
+                if (!simulationMode) {
+                    requirePrinter().printSelfTestPage();
+                }
+                return (simulationMode ? "模拟模式：" : "") + "自检页打印指令已接收";
+            }
+        });
+    }
+
+    void setShutdownTime(final int minutes) {
+        runPrinterAction("设置关机时间", new EmapiCommand(EmapiConstants.TYPE_REQUEST, EmapiConstants.PARENT_SYSTEM, EmapiConstants.CHILD_SYSTEM_SET_SHUTDOWN_TIME, EmapiPayload.uint16(minutes)), new PrinterCallable() {
+            @Override
+            public String call() throws Exception {
+                if (!simulationMode) {
+                    requirePrinter().setShutdownTime(minutes);
+                }
+                return (simulationMode ? "模拟模式：" : "") + "关机时间已设置为 " + minutes + " 分钟";
+            }
+        });
+    }
+
+    void queryRfidUid() {
+        runPrinterAction("查询 RFID 卡 UID", request(EmapiConstants.PARENT_RFID, EmapiConstants.CHILD_RFID_UID), new PrinterCallable() {
+            @Override
+            public String call() throws Exception {
+                return simulationMode ? "RFID 卡 UID：04AABBCCDDEE" : "RFID 卡 UID：" + requirePrinter().queryRfidUid();
+            }
+        });
+    }
+
+    void queryRfidCardInfo() {
+        runPrinterAction("查询 RFID 卡信息", request(EmapiConstants.PARENT_RFID, EmapiConstants.CHILD_RFID_CARD_INFO), new PrinterCallable() {
+            @Override
+            public String call() throws Exception {
+                EmapiRfidCardInfo info = simulationMode
+                    ? new EmapiRfidCardInfo("SIM-L801", "40m", "80mm", "white", "SIM-PAPER-01")
+                    : requirePrinter().queryRfidCardInfo();
+                return formatRfidCardInfo(info);
+            }
+        });
+    }
+
+    void queryRfidPaperLength() {
+        runPrinterAction("查询卡内纸张长度", request(EmapiConstants.PARENT_RFID, EmapiConstants.CHILD_RFID_PAPER_LENGTH), new PrinterCallable() {
+            @Override
+            public String call() throws Exception {
+                long length = simulationMode ? 123456L : requirePrinter().queryRfidPaperLength();
+                return "卡内纸张长度：" + length;
+            }
+        });
+    }
+
+    void setRfidAuthFailureHandling() {
+        runPrinterAction("设置 RFID 认证失败处理", new EmapiCommand(EmapiConstants.TYPE_REQUEST, EmapiConstants.PARENT_RFID, EmapiConstants.CHILD_RFID_AUTH_FAILURE_HANDLING, EmapiPayload.uint8(1)), new PrinterCallable() {
+            @Override
+            public String call() throws Exception {
+                if (!simulationMode) {
+                    requirePrinter().setRfidAuthFailureHandling(EmapiRfidAuthFailurePolicy.FORBID_PRINT);
+                }
+                return (simulationMode ? "模拟模式：" : "") + "RFID 认证失败处理：禁止打印";
+            }
+        });
+    }
+
+    void setWifiConfig(final String ssid, final String password) {
+        runPrinterAction("设置配网信息", null, new PrinterCallable() {
+            @Override
+            public String call() throws Exception {
+                if (simulationMode) {
+                    emitSimulatedReport(new EmapiWifiConfigStatusReport(new EmapiCommand(EmapiConstants.TYPE_PASSTHROUGH_REQUEST, EmapiConstants.PARENT_WIFI, EmapiConstants.CHILD_WIFI_CONFIG_STATUS, new byte[0]), ssid.length() == 0 ? "SIM_WIFI" : ssid, 1));
+                } else {
+                    requirePrinter().setWifiConfig(ssid, password);
+                }
+                return (simulationMode ? "模拟模式：" : "") + "配网信息已发送：SSID=" + (ssid.length() == 0 ? "SIM_WIFI" : ssid);
+            }
+        });
+    }
+
+    void queryWifiConnectionState() {
+        runPrinterAction("查询 WIFI 模块连接状态", passthrough(EmapiConstants.CHILD_WIFI_CONNECTION_STATE), new PrinterCallable() {
+            @Override
+            public String call() throws Exception {
+                EmapiWifiConnectionState state = simulationMode ? EmapiWifiConnectionState.IOT_CONNECTED : requirePrinter().queryWifiConnectionState();
+                return "WIFI 状态：" + state;
+            }
+        });
+    }
+
+    void queryWifiHotspotInfo() {
+        runPrinterAction("查询 WIFI 模块热点相关信息", passthrough(EmapiConstants.CHILD_WIFI_HOTSPOT_INFO), new PrinterCallable() {
+            @Override
+            public String call() throws Exception {
+                EmapiWifiHotspotInfo info = simulationMode
+                    ? new EmapiWifiHotspotInfo("SIM_AP", -42, "192.168.4.1", "9100")
+                    : requirePrinter().queryWifiHotspotInfo();
+                return "热点 SSID：" + value(info.getSsid()) + "\nRSSI：" + value(info.getRssi()) + "\nIP：" + value(info.getIp()) + "\nPort：" + value(info.getPort());
+            }
+        });
+    }
+
+    void queryDeviceInfo() {
+        runPrinterAction("查询打印机基本参数", request(EmapiConstants.PARENT_SYSTEM, EmapiConstants.CHILD_SYSTEM_DEVICE_INFO), new PrinterCallable() {
+            @Override
+            public String call() throws Exception {
+                EmapiPrinterInfo info = simulationMode
+                    ? new EmapiPrinterInfo("simulator", "EMAPI-SIM-01", "PSDK", "SIM0000001", "HW-SIM", "SW-SIM", "BOOT-SIM", 512)
+                    : requirePrinter().queryDeviceInfo();
+                if (info.getMtu() != null) {
+                    knownMtu = info.getMtu();
+                }
+                return "设备类型：" + value(info.getDeviceType()) + "\n设备型号：" + value(info.getDeviceModel()) + "\n品牌：" + value(info.getBrand()) + "\n序列号：" + value(info.getSerialNumber()) + "\n硬件版本：" + value(info.getHardwareVersion()) + "\n软件版本：" + value(info.getSoftwareVersion()) + "\nBoot：" + value(info.getBootVersion()) + "\nMTU：" + value(info.getMtu());
+            }
+        });
+    }
+
+    void queryPrintStatus() {
+        runPrinterAction("查询打印状态", request(EmapiConstants.PARENT_PRINTER, EmapiConstants.CHILD_PRINTER_STATUS), new PrinterCallable() {
+            @Override
+            public String call() throws Exception {
+                EmapiPrintStatus status = simulationMode
+                    ? new EmapiPrintStatus(1, 0, 0, 0, 86, 7400, 28)
+                    : requirePrinter().queryPrintStatus();
+                return "纸张：" + value(status.getPaperStatus()) + "\n开盖：" + value(status.getCoverStatus()) + "\n低电量：" + value(status.getLowBattery()) + "\n过热：" + value(status.getOverheat()) + "\n电量：" + value(status.getBatteryPercent()) + "\n电压：" + value(status.getBatteryVoltage()) + "\nTPH 温度：" + value(status.getTphTemperature());
+            }
+        });
+    }
+
+    void performWifiFileTransfer(final String path, final int fileType) {
+        runPrinterAction("WIFI 文件传输", null, new PrinterCallable() {
+            @Override
+            public String call() throws Exception {
+                byte[] bytes = simulationMode ? simulatedBytes(1536) : readRequiredFile(path, "请选择或输入 WIFI 文件路径");
+                int chunkSize = fileChunkSize();
+                transferSentBytes = 0;
+                transferTotalBytes = bytes.length;
+                latestTransferStatus = "WIFI 文件传输准备中";
+                addRequestLog(new LogEntry("WIFI 文件传输文件", "fileType=0x" + Integer.toHexString(fileType) + "，准备发送 " + bytes.length + " bytes，chunkSize=" + chunkSize, bytes));
+                if (simulationMode) {
+                    simulateTransfer(bytes, chunkSize, "WIFI 文件传输中");
+                } else {
+                    EmapiPrinter actual = requirePrinter();
+                    actual.startWifiFileDownload(fileType, bytes.length);
+                    transferChunks(bytes, chunkSize, new ChunkSender() {
+                        @Override
+                        public void send(int index, byte[] chunk) throws Exception {
+                            requirePrinter().transferWifiFileDownloadChunk(index, chunk);
+                        }
+                    }, "WIFI 文件传输中");
+                    actual.finishWifiFileDownload();
+                }
+                latestTransferStatus = "WIFI 文件传输完成";
+                return (simulationMode ? "模拟模式：" : "") + "WIFI 文件传输已完成\n" + transferProgress();
+            }
+        });
+    }
+
+    void performOta(final String path) {
+        runPrinterAction("OTA 升级", null, new PrinterCallable() {
+            @Override
+            public String call() throws Exception {
+                byte[] bytes = simulationMode ? simulatedBytes(2048) : readRequiredFile(path, "请选择或输入 OTA 文件路径");
+                int chunkSize = fileChunkSize();
+                transferSentBytes = 0;
+                transferTotalBytes = bytes.length;
+                latestTransferStatus = "OTA 升级准备中";
+                addRequestLog(new LogEntry("OTA 升级文件", "准备发送 " + bytes.length + " bytes，chunkSize=" + chunkSize, bytes));
+                if (simulationMode) {
+                    emitSimulatedReport(new EmapiUpgradeStatusReport(reportCommand(EmapiConstants.CHILD_REPORT_UPGRADE_STATUS), 1));
+                    simulateTransfer(bytes, chunkSize, "OTA 升级传输中");
+                    emitSimulatedReport(new EmapiUpgradeStatusReport(reportCommand(EmapiConstants.CHILD_REPORT_UPGRADE_STATUS), 0));
+                } else {
+                    EmapiPrinter actual = requirePrinter();
+                    actual.startMainControllerOta(bytes.length);
+                    transferChunks(bytes, chunkSize, new ChunkSender() {
+                        @Override
+                        public void send(int index, byte[] chunk) throws Exception {
+                            requirePrinter().transferMainControllerOtaChunk(index, chunk);
+                        }
+                    }, "OTA 升级传输中");
+                    actual.finishMainControllerOta();
+                    actual.upgradeMainController();
+                }
+                latestTransferStatus = "OTA 升级命令完成";
+                return (simulationMode ? "模拟模式：" : "") + "OTA 升级命令已完成\n" + transferProgress();
+            }
+        });
+    }
+
+    void performEscPrint(final String path, final EscPrintOptions options) {
+        runPrinterAction("ESC 图片打印", null, new PrinterCallable() {
+            @Override
+            public String call() throws Exception {
+                byte[] image = simulationMode ? simulatedBytes(256) : readRequiredFile(path, "请选择或输入 ESC 图片路径");
+                byte[] escBytes = EscCommandBuilder.buildImagePrint(image, options);
+                addRequestLog(new LogEntry("ESC 指令数据", "生成 " + escBytes.length + " bytes ESC 指令", escBytes));
+                if (!simulationMode) {
+                    requirePrinter().printEsc(escBytes);
+                } else {
+                    emitSimulatedReport(new EmapiPrintResultReport(reportCommand(EmapiConstants.CHILD_REPORT_PRINT_RESULT), 0));
+                }
+                return (simulationMode ? "模拟模式：" : "") + "ESC 图片打印指令已完成";
+            }
+        });
+    }
+
+    void destroy(Context context) {
+        stopScan(context);
+        reportLoopRunning = false;
+        disconnect();
+        executor.shutdownNow();
+    }
+
+    private void runPrinterAction(final String label, final EmapiCommand requestCommand, final PrinterCallable callable) {
+        if (busy()) {
+            return;
+        }
+        pendingActionLabel = label;
+        final int traceStart = tracingConnection == null ? 0 : tracingConnection.mark();
+        if (requestCommand != null) {
+            addRequestLog(new LogEntry(label, requestCommand.toString(), FrameCodec.encode(requestCommand)));
+        }
+        notifyChanged();
+        executor.execute(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    String result = callable.call();
+                    addActualOutboundLog(label, traceStart);
+                    byte[] inbound = tracingConnection == null ? null : tracingConnection.bytesSince(traceStart, TracingEmapiConnection.INBOUND);
+                    addCommandEntry(new LogEntry(label, result, inbound));
+                } catch (Exception error) {
+                    addActualOutboundLog(label, traceStart);
+                    addCommandEntry(new LogEntry(label, formatError(error)));
+                } finally {
+                    pendingActionLabel = null;
+                    notifyChanged();
+                }
+            }
+        });
+    }
+
+    private void startReportLoop() {
+        reportLoopRunning = true;
+        executor.execute(new Runnable() {
+            @Override
+            public void run() {
+                while (reportLoopRunning && printer != null) {
+                    try {
+                        handleReport(printer.readNextReport());
+                    } catch (Exception ignored) {
+                        return;
+                    }
+                }
+            }
+        });
+    }
+
+    private void handleReport(EmapiReport report) {
+        String message = formatReport(report);
+        if (report instanceof EmapiUpgradeStatusReport || report instanceof EmapiFlowControlReport) {
+            latestTransferStatus = message;
+        }
+        reportLogs.add(0, new LogEntry("上报解析", message, FrameCodec.encode(report.getCommand())));
+        notifyChanged();
+    }
+
+    private void emitSimulatedReport(EmapiReport report) {
+        handleReport(report);
+    }
+
+    private EmapiPrinter requirePrinter() {
+        if (printer == null) {
+            throw new IllegalStateException("打印机未连接");
+        }
+        return printer;
+    }
+
+    private void addBondedDevices() {
+        try {
+            Set<BluetoothDevice> bondedDevices = bluetoothAdapter.getBondedDevices();
+            for (BluetoothDevice device : bondedDevices) {
+                devices.add(new DeviceModel(device.getName(), device.getAddress(), "Bluetooth Classic", false));
+            }
+        } catch (SecurityException error) {
+            addCommandLog("读取已配对设备失败：" + error.getMessage());
+        }
+    }
+
+    private void registerScanReceiver(Context context) {
+        if (scanReceiver != null) {
+            return;
+        }
+        scanReceiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                if (BluetoothDevice.ACTION_FOUND.equals(intent.getAction())) {
+                    BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
+                    if (device != null) {
+                        try {
+                            devices.add(new DeviceModel(device.getName(), device.getAddress(), "Bluetooth Classic", false));
+                            notifyChanged();
+                        } catch (SecurityException ignored) {
+                        }
+                    }
+                }
+            }
+        };
+        context.registerReceiver(scanReceiver, new IntentFilter(BluetoothDevice.ACTION_FOUND));
+    }
+
+    private void unregisterScanReceiver(Context context) {
+        if (scanReceiver == null) {
+            return;
+        }
+        try {
+            context.unregisterReceiver(scanReceiver);
+        } catch (IllegalArgumentException ignored) {
+        }
+        scanReceiver = null;
+    }
+
+    private void addActualOutboundLog(String label, int traceStart) {
+        if (tracingConnection == null) {
+            return;
+        }
+        byte[] outbound = tracingConnection.bytesSince(traceStart, TracingEmapiConnection.OUTBOUND);
+        if (outbound != null) {
+            addRequestLog(new LogEntry(label + " 实际发送", "真实连接写出的帧数据", outbound));
+        }
+    }
+
+    private void transferChunks(byte[] bytes, int chunkSize, ChunkSender sender, String status) throws Exception {
+        int index = 1;
+        for (int offset = 0; offset < bytes.length; offset += chunkSize) {
+            int end = Math.min(offset + chunkSize, bytes.length);
+            byte[] chunk = new byte[end - offset];
+            System.arraycopy(bytes, offset, chunk, 0, chunk.length);
+            sender.send(index++, chunk);
+            transferSentBytes = end;
+            latestTransferStatus = status;
+            notifyChanged();
+        }
+    }
+
+    private void simulateTransfer(byte[] bytes, int chunkSize, String status) throws InterruptedException {
+        for (int offset = 0; offset < bytes.length; offset += chunkSize) {
+            Thread.sleep(60);
+            transferSentBytes = Math.min(offset + chunkSize, bytes.length);
+            latestTransferStatus = status;
+            notifyChanged();
+        }
+    }
+
+    private byte[] readRequiredFile(String path, String emptyMessage) throws IOException {
+        if (path == null || path.trim().length() == 0) {
+            throw new IllegalArgumentException(emptyMessage);
+        }
+        File file = new File(path.trim());
+        if (!file.exists() || file.length() == 0) {
+            throw new IllegalArgumentException("文件不存在或为空：" + path);
+        }
+        byte[] bytes = new byte[(int) file.length()];
+        FileInputStream input = new FileInputStream(file);
+        try {
+            int offset = 0;
+            while (offset < bytes.length) {
+                int count = input.read(bytes, offset, bytes.length - offset);
+                if (count < 0) {
+                    break;
+                }
+                offset += count;
+            }
+            return bytes;
+        } finally {
+            input.close();
+        }
+    }
+
+    private int fileChunkSize() {
+        int capacity = knownMtu - EmapiConstants.FRAME_OVERHEAD_LENGTH - EmapiConstants.COMMAND_HEADER_LENGTH - 4;
+        int aligned = (capacity / 32) * 32;
+        return Math.max(32, aligned);
+    }
+
+    private byte[] simulatedBytes(int length) {
+        byte[] data = new byte[length];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) (i & 0xff);
+        }
+        return data;
+    }
+
+    private EmapiCommand request(int parent, int child) {
+        return new EmapiCommand(EmapiConstants.TYPE_REQUEST, parent, child, new byte[0]);
+    }
+
+    private EmapiCommand passthrough(int child) {
+        return new EmapiCommand(EmapiConstants.TYPE_PASSTHROUGH_REQUEST, EmapiConstants.PARENT_WIFI, child, new byte[0]);
+    }
+
+    private EmapiCommand reportCommand(int child) {
+        return new EmapiCommand(EmapiConstants.TYPE_REQUEST, EmapiConstants.PARENT_REPORT, child, new byte[0]);
+    }
+
+    private String formatRfidCardInfo(EmapiRfidCardInfo info) {
+        return "纸张型号：" + value(info.getPaperModel()) + "\n纸张长度：" + value(info.getPaperLength()) + "\n纸张宽度：" + value(info.getPaperWidth()) + "\n纸张颜色：" + value(info.getPaperColor()) + "\n物料号：" + value(info.getPaperMaterialNumber());
+    }
+
+    private String formatReport(EmapiReport report) {
+        if (report instanceof EmapiPrintResultReport) {
+            return "打印结果上报：result=" + ((EmapiPrintResultReport) report).getResult();
+        }
+        if (report instanceof EmapiPrinterStatusReport) {
+            EmapiPrinterStatusReport status = (EmapiPrinterStatusReport) report;
+            return "打印机状态上报：paper=" + value(status.getPaperStatus()) + " cover=" + value(status.getCoverStatus()) + " battery=" + value(status.getBatteryState()) + " overheat=" + value(status.getOverheat()) + " nfc=" + value(status.getNfcPaperRecognition());
+        }
+        if (report instanceof EmapiFlowControlReport) {
+            return "流控上报：" + (((EmapiFlowControlReport) report).isBusy() ? "忙碌" : "空闲");
+        }
+        if (report instanceof EmapiUpgradeStatusReport) {
+            return "升级状态上报：status=" + ((EmapiUpgradeStatusReport) report).getStatus();
+        }
+        if (report instanceof EmapiBluetoothConnectionReport) {
+            return "蓝牙连接上报：state=" + ((EmapiBluetoothConnectionReport) report).getState();
+        }
+        if (report instanceof EmapiWifiConfigStatusReport) {
+            EmapiWifiConfigStatusReport status = (EmapiWifiConfigStatusReport) report;
+            return "WIFI 配网上报：SSID=" + value(status.getSsid()) + " state=" + value(status.getState());
+        }
+        if (report instanceof EmapiUnknownReport) {
+            return "未知上报：" + report.getCommand();
+        }
+        return "上报：" + report.getCommand();
+    }
+
+    private String formatError(Throwable error) {
+        return error.getClass().getSimpleName() + "：" + (error.getMessage() == null ? "" : error.getMessage());
+    }
+
+    private String value(Object value) {
+        return value == null ? "-" : String.valueOf(value);
+    }
+
+    private void addCommandLog(String message) {
+        addCommandEntry(new LogEntry("系统消息", message));
+    }
+
+    private void addCommandEntry(LogEntry entry) {
+        commandLogs.add(0, entry);
+    }
+
+    private void addRequestLog(LogEntry entry) {
+        requestLogs.add(0, entry);
+    }
+
+    private void notifyChanged() {
+        mainHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                listener.onChanged();
+            }
+        });
+    }
+
+    private interface PrinterCallable {
+        String call() throws Exception;
+    }
+
+    private interface ChunkSender {
+        void send(int index, byte[] chunk) throws Exception;
+    }
+}

--- a/android-native-java/emapi-android-demo/app/src/main/java/com/printer/psdk/examples/emapi/EscCommandBuilder.java
+++ b/android-native-java/emapi-android-demo/app/src/main/java/com/printer/psdk/examples/emapi/EscCommandBuilder.java
@@ -1,0 +1,29 @@
+package com.printer.psdk.examples.emapi;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+final class EscCommandBuilder {
+    private EscCommandBuilder() {
+    }
+
+    static byte[] buildImagePrint(byte[] imageBytes, EscPrintOptions options) {
+        byte[] image = imageBytes == null || imageBytes.length == 0
+            ? new byte[]{0x45, 0x4d, 0x41, 0x50, 0x49}
+            : imageBytes;
+        EscPrintOptions actual = options == null ? new EscPrintOptions() : options;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try {
+            out.write(new byte[]{0x1b, 0x40});
+            out.write(new byte[]{0x1f, 0x11, (byte) actual.paperType});
+            out.write(new byte[]{0x1f, 0x12, (byte) actual.printMode});
+            out.write(new byte[]{0x1f, 0x13, (byte) actual.thickness});
+            out.write(new byte[]{0x1f, 0x14, (byte) (actual.compress ? 1 : 0)});
+            out.write(image);
+            out.write(new byte[]{0x0c, 0x1b, 0x4a, 0x00});
+            return out.toByteArray();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to build ESC bytes", e);
+        }
+    }
+}

--- a/android-native-java/emapi-android-demo/app/src/main/java/com/printer/psdk/examples/emapi/EscPrintOptions.java
+++ b/android-native-java/emapi-android-demo/app/src/main/java/com/printer/psdk/examples/emapi/EscPrintOptions.java
@@ -1,0 +1,15 @@
+package com.printer.psdk.examples.emapi;
+
+final class EscPrintOptions {
+    static final int PAPER_CONTINUOUS = 0;
+    static final int PAPER_GAP = 1;
+    static final int PAPER_BLACK_MARK = 2;
+    static final int MODE_NORMAL = 0;
+    static final int MODE_DOUBLE = 1;
+    static final int MODE_GRAY = 2;
+
+    int paperType = PAPER_CONTINUOUS;
+    int printMode = MODE_NORMAL;
+    int thickness = 8;
+    boolean compress = true;
+}

--- a/android-native-java/emapi-android-demo/app/src/main/java/com/printer/psdk/examples/emapi/Hex.java
+++ b/android-native-java/emapi-android-demo/app/src/main/java/com/printer/psdk/examples/emapi/Hex.java
@@ -1,0 +1,28 @@
+package com.printer.psdk.examples.emapi;
+
+final class Hex {
+    private static final char[] TABLE = "0123456789ABCDEF".toCharArray();
+
+    private Hex() {
+    }
+
+    static String bytes(byte[] data) {
+        if (data == null || data.length == 0) {
+            return "";
+        }
+        StringBuilder builder = new StringBuilder(data.length * 3);
+        for (int i = 0; i < data.length; i++) {
+            if (i > 0) {
+                builder.append(' ');
+            }
+            int value = data[i] & 0xff;
+            builder.append(TABLE[value >>> 4]).append(TABLE[value & 0x0f]);
+        }
+        return builder.toString();
+    }
+
+    static String command(byte[] data) {
+        String hex = bytes(data);
+        return hex.length() == 0 ? "无字节数据" : hex;
+    }
+}

--- a/android-native-java/emapi-android-demo/app/src/main/java/com/printer/psdk/examples/emapi/LogEntry.java
+++ b/android-native-java/emapi-android-demo/app/src/main/java/com/printer/psdk/examples/emapi/LogEntry.java
@@ -1,0 +1,17 @@
+package com.printer.psdk.examples.emapi;
+
+final class LogEntry {
+    final String title;
+    final String message;
+    final byte[] bytes;
+
+    LogEntry(String title, String message) {
+        this(title, message, null);
+    }
+
+    LogEntry(String title, String message, byte[] bytes) {
+        this.title = title;
+        this.message = message;
+        this.bytes = bytes == null ? null : bytes.clone();
+    }
+}

--- a/android-native-java/emapi-android-demo/app/src/main/java/com/printer/psdk/examples/emapi/MainActivity.java
+++ b/android-native-java/emapi-android-demo/app/src/main/java/com/printer/psdk/examples/emapi/MainActivity.java
@@ -1,0 +1,561 @@
+package com.printer.psdk.examples.emapi;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.provider.Settings;
+import android.text.InputType;
+import android.view.Gravity;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.CheckBox;
+import android.widget.CompoundButton;
+import android.widget.EditText;
+import android.widget.LinearLayout;
+import android.widget.ProgressBar;
+import android.widget.RadioButton;
+import android.widget.RadioGroup;
+import android.widget.ScrollView;
+import android.widget.SeekBar;
+import android.widget.Spinner;
+import android.widget.TextView;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.util.List;
+
+public final class MainActivity extends Activity implements EmapiDemoController.Listener {
+    private static final int PICK_WIFI_FILE = 1;
+    private static final int PICK_OTA_FILE = 2;
+    private static final int PICK_ESC_IMAGE = 3;
+
+    private EmapiDemoController controller;
+    private LinearLayout root;
+    private LinearLayout content;
+    private int page = 0;
+    private int logTab = 0;
+    private EditText activePathField;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        controller = new EmapiDemoController(this);
+        controller.init(this);
+        render();
+    }
+
+    @Override
+    protected void onDestroy() {
+        controller.destroy(this);
+        super.onDestroy();
+    }
+
+    @Override
+    public void onChanged() {
+        render();
+    }
+
+    private void render() {
+        if (root == null) {
+            root = new LinearLayout(this);
+            root.setOrientation(LinearLayout.VERTICAL);
+            root.setBackgroundColor(0xfff6f7f2);
+            setContentView(root);
+        }
+        root.removeAllViews();
+        root.addView(topBar());
+        ScrollView scrollView = new ScrollView(this);
+        content = new LinearLayout(this);
+        content.setOrientation(LinearLayout.VERTICAL);
+        content.setPadding(dp(16), dp(12), dp(16), dp(16));
+        scrollView.addView(content);
+        root.addView(scrollView, new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0, 1));
+        if (page == 1) {
+            renderSettingsPage();
+        } else if (controller.connected) {
+            renderFunctionPage();
+        } else {
+            renderScanPage();
+        }
+    }
+
+    private View topBar() {
+        LinearLayout bar = new LinearLayout(this);
+        bar.setOrientation(LinearLayout.HORIZONTAL);
+        bar.setGravity(Gravity.CENTER_VERTICAL);
+        bar.setPadding(dp(16), dp(10), dp(16), dp(10));
+        bar.setBackgroundColor(0xffffffff);
+        TextView title = new TextView(this);
+        title.setText("EMAPI Android Demo");
+        title.setTextSize(20);
+        title.setTextColor(0xff18201d);
+        title.setGravity(Gravity.CENTER_VERTICAL);
+        bar.addView(title, new LinearLayout.LayoutParams(0, dp(44), 1));
+        Button settings = compactButton(page == 1 ? "返回" : "设置");
+        settings.setEnabled(!controller.busy());
+        settings.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                page = page == 1 ? 0 : 1;
+                render();
+            }
+        });
+        bar.addView(settings);
+        if (controller.connected) {
+            Button disconnect = compactButton("断开");
+            disconnect.setEnabled(!controller.busy());
+            disconnect.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    controller.disconnect();
+                }
+            });
+            bar.addView(disconnect);
+        }
+        return bar;
+    }
+
+    private void renderScanPage() {
+        addPanel(controller.simulationMode ? "模拟测试台" : "蓝牙设备", controller.simulationMode
+            ? "生成模拟蓝牙设备，并使用模拟 EMAPI 操作结果完成全流程。"
+            : (controller.bluetoothEnabled ? "扫描附近或已配对的蓝牙打印机。" : "蓝牙未开启，开启后可扫描真实设备。"));
+        LinearLayout row = new LinearLayout(this);
+        row.setOrientation(LinearLayout.HORIZONTAL);
+        Button start = button(controller.scanning ? "扫描中" : "开始扫描");
+        start.setEnabled(!controller.busy() && !controller.scanning);
+        start.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                controller.startScan(MainActivity.this);
+            }
+        });
+        row.addView(start, new LinearLayout.LayoutParams(0, dp(48), 1));
+        Button stop = button("停止");
+        stop.setEnabled(controller.scanning && !controller.busy());
+        stop.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                controller.stopScan(MainActivity.this);
+            }
+        });
+        row.addView(stop, new LinearLayout.LayoutParams(0, dp(48), 1));
+        content.addView(row);
+        sectionTitle("设备列表");
+        if (controller.devices.isEmpty()) {
+            TextView empty = body("暂无设备，点击开始扫描。");
+            empty.setGravity(Gravity.CENTER);
+            content.addView(empty, matchWrap());
+        } else {
+            for (final DeviceModel device : controller.devices) {
+                LinearLayout item = card();
+                item.setOrientation(LinearLayout.HORIZONTAL);
+                TextView text = body(device.name + "\n" + device.protocol + " / " + device.address);
+                item.addView(text, new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1));
+                Button connect = compactButton("连接");
+                connect.setEnabled(!controller.busy());
+                connect.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        controller.connect(device);
+                    }
+                });
+                item.addView(connect);
+                content.addView(item);
+            }
+        }
+    }
+
+    private void renderSettingsPage() {
+        sectionTitle("设置");
+        LinearLayout panel = card();
+        panel.setOrientation(LinearLayout.VERTICAL);
+        TextView title = title("测试模式");
+        panel.addView(title);
+        CheckBox simulation = new CheckBox(this);
+        simulation.setText("模拟模式");
+        simulation.setTextSize(16);
+        simulation.setChecked(controller.simulationMode);
+        simulation.setEnabled(!controller.busy());
+        simulation.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                controller.setSimulationMode(isChecked);
+            }
+        });
+        panel.addView(simulation);
+        panel.addView(body("开启后会生成模拟蓝牙设备，并返回模拟 EMAPI 操作结果；切换模式会断开当前设备并重置扫描状态。"));
+        content.addView(panel);
+    }
+
+    private void renderFunctionPage() {
+        addPanel(controller.connectedDeviceName == null ? "EMAPI printer" : controller.connectedDeviceName,
+            (controller.pendingActionLabel == null ? "等待操作" : "正在执行：" + controller.pendingActionLabel) + "\n" + (controller.simulationMode ? "模拟模式" : "真实蓝牙连接"));
+        renderLogTabs();
+        renderOperationArea();
+    }
+
+    private void renderLogTabs() {
+        LinearLayout tabs = new LinearLayout(this);
+        tabs.setOrientation(LinearLayout.HORIZONTAL);
+        String[] labels = {"发送指令", "命令结果", "上报解析"};
+        for (int i = 0; i < labels.length; i++) {
+            final int index = i;
+            Button tab = compactButton(labels[i]);
+            tab.setEnabled(logTab != index);
+            tab.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    logTab = index;
+                    render();
+                }
+            });
+            tabs.addView(tab, new LinearLayout.LayoutParams(0, dp(42), 1));
+        }
+        content.addView(tabs);
+        List<LogEntry> logs = logTab == 0 ? controller.requestLogs : logTab == 1 ? controller.commandLogs : controller.reportLogs;
+        if (logs.isEmpty()) {
+            content.addView(body("暂无日志"));
+            return;
+        }
+        for (LogEntry entry : logs) {
+            LinearLayout card = card();
+            card.setOrientation(LinearLayout.VERTICAL);
+            card.addView(title(entry.title));
+            card.addView(body(entry.message));
+            if (entry.bytes != null) {
+                TextView bytes = body(Hex.command(entry.bytes));
+                bytes.setTextSize(12);
+                card.addView(bytes);
+            }
+            content.addView(card);
+        }
+    }
+
+    private void renderOperationArea() {
+        sectionTitle("功能区");
+        String[] labels = {"休眠关机", "打印自检页", "设置关机时间", "RFID UID", "RFID 信息", "纸张长度", "RFID 失败处理", "配网信息", "WIFI 状态", "热点信息", "WiFi 文件传输", "基本参数", "打印状态", "ESC 打印", "OTA 升级"};
+        View.OnClickListener[] handlers = {
+            new View.OnClickListener() { public void onClick(View v) { controller.sleepShutdown(); } },
+            new View.OnClickListener() { public void onClick(View v) { controller.printSelfTestPage(); } },
+            new View.OnClickListener() { public void onClick(View v) { showShutdownDialog(); } },
+            new View.OnClickListener() { public void onClick(View v) { controller.queryRfidUid(); } },
+            new View.OnClickListener() { public void onClick(View v) { controller.queryRfidCardInfo(); } },
+            new View.OnClickListener() { public void onClick(View v) { controller.queryRfidPaperLength(); } },
+            new View.OnClickListener() { public void onClick(View v) { controller.setRfidAuthFailureHandling(); } },
+            new View.OnClickListener() { public void onClick(View v) { showWifiDialog(); } },
+            new View.OnClickListener() { public void onClick(View v) { controller.queryWifiConnectionState(); } },
+            new View.OnClickListener() { public void onClick(View v) { controller.queryWifiHotspotInfo(); } },
+            new View.OnClickListener() { public void onClick(View v) { showWifiFileDialog(); } },
+            new View.OnClickListener() { public void onClick(View v) { controller.queryDeviceInfo(); } },
+            new View.OnClickListener() { public void onClick(View v) { controller.queryPrintStatus(); } },
+            new View.OnClickListener() { public void onClick(View v) { showEscDialog(); } },
+            new View.OnClickListener() { public void onClick(View v) { showOtaDialog(); } }
+        };
+        for (int i = 0; i < labels.length; i += 3) {
+            LinearLayout row = new LinearLayout(this);
+            row.setOrientation(LinearLayout.HORIZONTAL);
+            for (int j = i; j < Math.min(i + 3, labels.length); j++) {
+                Button item = compactButton(labels[j]);
+                item.setEnabled(!controller.busy());
+                item.setOnClickListener(handlers[j]);
+                row.addView(item, new LinearLayout.LayoutParams(0, dp(54), 1));
+            }
+            content.addView(row);
+        }
+        TextView progress = body(controller.transferProgress());
+        progress.setGravity(Gravity.CENTER);
+        content.addView(progress);
+        ProgressBar bar = new ProgressBar(this, null, android.R.attr.progressBarStyleHorizontal);
+        bar.setMax(Math.max(controller.transferTotalBytes, 1));
+        bar.setProgress(controller.transferSentBytes);
+        content.addView(bar, matchWrap());
+    }
+
+    private void showShutdownDialog() {
+        final String[] values = {"15", "30", "60"};
+        new AlertDialog.Builder(this)
+            .setTitle("设置关机时间")
+            .setSingleChoiceItems(values, 1, null)
+            .setPositiveButton("提交", new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    int selected = ((AlertDialog) dialog).getListView().getCheckedItemPosition();
+                    controller.setShutdownTime(Integer.parseInt(values[selected < 0 ? 1 : selected]));
+                }
+            })
+            .setNegativeButton("取消", null)
+            .show();
+    }
+
+    private void showWifiDialog() {
+        LinearLayout form = form();
+        final EditText ssid = field("WiFi SSID", false);
+        final EditText password = field("WiFi 密码", true);
+        form.addView(ssid);
+        form.addView(password);
+        new AlertDialog.Builder(this)
+            .setTitle("配网信息")
+            .setView(form)
+            .setPositiveButton("提交", new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    controller.setWifiConfig(ssid.getText().toString(), password.getText().toString());
+                }
+            })
+            .setNegativeButton("取消", null)
+            .show();
+    }
+
+    private void showWifiFileDialog() {
+        LinearLayout form = form();
+        final EditText path = field("文件路径", false);
+        final Spinner type = new Spinner(this);
+        type.setAdapter(new ArrayAdapter<String>(this, android.R.layout.simple_spinner_dropdown_item, new String[]{
+            "0x0001 WiFi主控升级文件(.bin)",
+            "0x0002 日历图像文件",
+            "0x0003 待机图像文件"
+        }));
+        Button pick = button("选择文件");
+        pick.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                activePathField = path;
+                pickFile(PICK_WIFI_FILE);
+            }
+        });
+        form.addView(path);
+        form.addView(type);
+        form.addView(pick);
+        new AlertDialog.Builder(this)
+            .setTitle("WiFi 文件传输")
+            .setView(form)
+            .setPositiveButton("开始传输", new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    controller.performWifiFileTransfer(path.getText().toString(), type.getSelectedItemPosition() + 1);
+                }
+            })
+            .setNegativeButton("取消", null)
+            .show();
+    }
+
+    private void showOtaDialog() {
+        LinearLayout form = form();
+        final EditText path = field("OTA 文件路径", false);
+        Button pick = button("选择 OTA 文件");
+        pick.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                activePathField = path;
+                pickFile(PICK_OTA_FILE);
+            }
+        });
+        form.addView(path);
+        form.addView(pick);
+        new AlertDialog.Builder(this)
+            .setTitle("OTA 升级")
+            .setView(form)
+            .setPositiveButton("开始 OTA 升级", new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    controller.performOta(path.getText().toString());
+                }
+            })
+            .setNegativeButton("取消", null)
+            .show();
+    }
+
+    private void showEscDialog() {
+        LinearLayout form = form();
+        final EditText path = field("图片路径", false);
+        Button pick = button("选择图片");
+        pick.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                activePathField = path;
+                pickFile(PICK_ESC_IMAGE);
+            }
+        });
+        final RadioGroup paper = radioGroup(new String[]{"连续", "间隙", "黑标"});
+        final RadioGroup mode = radioGroup(new String[]{"普通", "双重", "灰阶"});
+        final SeekBar thickness = new SeekBar(this);
+        thickness.setMax(15);
+        thickness.setProgress(8);
+        final TextView thicknessLabel = body("厚度：8");
+        thickness.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+            @Override public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) { thicknessLabel.setText("厚度：" + progress); }
+            @Override public void onStartTrackingTouch(SeekBar seekBar) { }
+            @Override public void onStopTrackingTouch(SeekBar seekBar) { }
+        });
+        final CheckBox compress = new CheckBox(this);
+        compress.setText("图像压缩");
+        compress.setChecked(false);
+        form.addView(path);
+        form.addView(pick);
+        form.addView(body("纸张类型"));
+        form.addView(paper);
+        form.addView(body("打印模式"));
+        form.addView(mode);
+        form.addView(thicknessLabel);
+        form.addView(thickness);
+        form.addView(compress);
+        new AlertDialog.Builder(this)
+            .setTitle("ESC 打印")
+            .setView(form)
+            .setPositiveButton("开始打印", new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    EscPrintOptions options = new EscPrintOptions();
+                    options.paperType = selectedRadioIndex(paper);
+                    options.printMode = selectedRadioIndex(mode);
+                    options.thickness = thickness.getProgress();
+                    options.compress = compress.isChecked();
+                    controller.performEscPrint(path.getText().toString(), options);
+                }
+            })
+            .setNegativeButton("取消", null)
+            .show();
+    }
+
+    private void pickFile(int requestCode) {
+        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+        intent.addCategory(Intent.CATEGORY_OPENABLE);
+        intent.setType("*/*");
+        startActivityForResult(intent, requestCode);
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (resultCode != RESULT_OK || data == null || activePathField == null) {
+            return;
+        }
+        Uri uri = data.getData();
+        if (uri == null) {
+            return;
+        }
+        try {
+            File file = new File(getCacheDir(), "emapi-selected-" + requestCode + ".bin");
+            InputStream input = getContentResolver().openInputStream(uri);
+            FileOutputStream output = new FileOutputStream(file);
+            byte[] buffer = new byte[8192];
+            int count;
+            while (input != null && (count = input.read(buffer)) >= 0) {
+                output.write(buffer, 0, count);
+            }
+            if (input != null) {
+                input.close();
+            }
+            output.close();
+            activePathField.setText(file.getAbsolutePath());
+        } catch (Exception error) {
+            activePathField.setText(uri.toString());
+        }
+    }
+
+    private void addPanel(String title, String message) {
+        LinearLayout panel = card();
+        panel.setOrientation(LinearLayout.VERTICAL);
+        panel.addView(title(title));
+        panel.addView(body(message));
+        content.addView(panel);
+    }
+
+    private void sectionTitle(String text) {
+        TextView view = title(text);
+        view.setPadding(0, dp(18), 0, dp(8));
+        content.addView(view);
+    }
+
+    private LinearLayout card() {
+        LinearLayout card = new LinearLayout(this);
+        card.setPadding(dp(12), dp(12), dp(12), dp(12));
+        card.setBackgroundColor(0xffffffff);
+        LinearLayout.LayoutParams params = matchWrap();
+        params.setMargins(0, 0, 0, dp(10));
+        card.setLayoutParams(params);
+        return card;
+    }
+
+    private TextView title(String text) {
+        TextView view = new TextView(this);
+        view.setText(text);
+        view.setTextColor(0xff18201d);
+        view.setTextSize(18);
+        view.setGravity(Gravity.CENTER_VERTICAL);
+        return view;
+    }
+
+    private TextView body(String text) {
+        TextView view = new TextView(this);
+        view.setText(text);
+        view.setTextColor(0xff39433e);
+        view.setTextSize(14);
+        view.setPadding(0, dp(4), 0, dp(4));
+        return view;
+    }
+
+    private Button button(String text) {
+        Button view = new Button(this);
+        view.setText(text);
+        view.setAllCaps(false);
+        return view;
+    }
+
+    private Button compactButton(String text) {
+        Button view = button(text);
+        view.setMinHeight(0);
+        view.setMinWidth(0);
+        view.setPadding(dp(8), 0, dp(8), 0);
+        return view;
+    }
+
+    private EditText field(String hint, boolean password) {
+        EditText field = new EditText(this);
+        field.setHint(hint);
+        field.setSingleLine(true);
+        if (password) {
+            field.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
+        }
+        return field;
+    }
+
+    private LinearLayout form() {
+        LinearLayout form = new LinearLayout(this);
+        form.setOrientation(LinearLayout.VERTICAL);
+        form.setPadding(dp(8), dp(8), dp(8), 0);
+        return form;
+    }
+
+    private RadioGroup radioGroup(String[] labels) {
+        RadioGroup group = new RadioGroup(this);
+        group.setOrientation(RadioGroup.HORIZONTAL);
+        for (int i = 0; i < labels.length; i++) {
+            RadioButton item = new RadioButton(this);
+            item.setText(labels[i]);
+            item.setId(100 + i);
+            group.addView(item);
+        }
+        group.check(100);
+        return group;
+    }
+
+    private int selectedRadioIndex(RadioGroup group) {
+        return Math.max(0, group.getCheckedRadioButtonId() - 100);
+    }
+
+    private LinearLayout.LayoutParams matchWrap() {
+        return new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+    }
+
+    private int dp(int value) {
+        return (int) (value * getResources().getDisplayMetrics().density + 0.5f);
+    }
+}

--- a/android-native-java/emapi-android-demo/app/src/main/java/com/printer/psdk/examples/emapi/TracingEmapiConnection.java
+++ b/android-native-java/emapi-android-demo/app/src/main/java/com/printer/psdk/examples/emapi/TracingEmapiConnection.java
@@ -1,0 +1,82 @@
+package com.printer.psdk.examples.emapi;
+
+import com.printer.psdk.emapi.EmapiConnection;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+final class TracingEmapiConnection implements EmapiConnection {
+    static final int OUTBOUND = 1;
+    static final int INBOUND = 2;
+
+    static final class Frame {
+        final int direction;
+        final byte[] data;
+
+        Frame(int direction, byte[] data) {
+            this.direction = direction;
+            this.data = data == null ? new byte[0] : data.clone();
+        }
+    }
+
+    private final EmapiConnection inner;
+    private final List<Frame> frames = new ArrayList<Frame>();
+
+    TracingEmapiConnection(EmapiConnection inner) {
+        this.inner = inner;
+    }
+
+    int mark() {
+        return frames.size();
+    }
+
+    byte[] bytesSince(int mark, int direction) {
+        if (mark >= frames.size()) {
+            return null;
+        }
+        int total = 0;
+        for (int i = mark; i < frames.size(); i++) {
+            Frame frame = frames.get(i);
+            if (frame.direction == direction) {
+                total += frame.data.length + (total == 0 ? 0 : 2);
+            }
+        }
+        if (total == 0) {
+            return null;
+        }
+        byte[] result = new byte[total];
+        int offset = 0;
+        for (int i = mark; i < frames.size(); i++) {
+            Frame frame = frames.get(i);
+            if (frame.direction != direction) {
+                continue;
+            }
+            if (offset > 0) {
+                result[offset++] = 0x0d;
+                result[offset++] = 0x0a;
+            }
+            System.arraycopy(frame.data, 0, result, offset, frame.data.length);
+            offset += frame.data.length;
+        }
+        return result;
+    }
+
+    @Override
+    public void write(byte[] data) throws IOException {
+        frames.add(new Frame(OUTBOUND, data));
+        inner.write(data);
+    }
+
+    @Override
+    public byte[] read(int timeoutMs) throws IOException {
+        byte[] data = inner.read(timeoutMs);
+        frames.add(new Frame(INBOUND, data));
+        return data;
+    }
+
+    @Override
+    public void close() throws IOException {
+        inner.close();
+    }
+}

--- a/android-native-java/emapi-android-demo/app/src/main/res/values/colors.xml
+++ b/android-native-java/emapi-android-demo/app/src/main/res/values/colors.xml
@@ -1,0 +1,6 @@
+<resources>
+    <color name="emapi_bg">#F6F7F2</color>
+    <color name="emapi_panel">#FFFFFF</color>
+    <color name="emapi_primary">#176B5B</color>
+    <color name="emapi_text">#18201D</color>
+</resources>

--- a/android-native-java/emapi-android-demo/app/src/main/res/values/strings.xml
+++ b/android-native-java/emapi-android-demo/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">EMAPI Android Demo</string>
+</resources>

--- a/android-native-java/emapi-android-demo/app/src/main/res/values/themes.xml
+++ b/android-native-java/emapi-android-demo/app/src/main/res/values/themes.xml
@@ -1,0 +1,8 @@
+<resources>
+    <style name="AppTheme" parent="android:style/Theme.Material.Light.NoActionBar">
+        <item name="android:fontFamily">sans</item>
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:colorAccent">@color/emapi_primary</item>
+        <item name="android:navigationBarColor">@color/emapi_bg</item>
+    </style>
+</resources>

--- a/android-native-java/emapi-android-demo/app/src/test/java/com/printer/psdk/examples/emapi/EmapiAndroidDemoContractTest.java
+++ b/android-native-java/emapi-android-demo/app/src/test/java/com/printer/psdk/examples/emapi/EmapiAndroidDemoContractTest.java
@@ -1,0 +1,48 @@
+package com.printer.psdk.examples.emapi;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+public class EmapiAndroidDemoContractTest {
+    @Test
+    public void mainActivity_containsFlutterParityLabels() throws Exception {
+        String source = read("src/main/java/com/printer/psdk/examples/emapi/MainActivity.java");
+        String[] labels = {
+            "EMAPI Android Demo", "设置", "断开", "蓝牙设备", "模拟测试台", "开始扫描", "扫描中", "停止", "设备列表",
+            "测试模式", "模拟模式", "发送指令", "命令结果", "上报解析", "休眠关机", "打印自检页",
+            "设置关机时间", "RFID UID", "RFID 信息", "纸张长度", "RFID 失败处理", "配网信息",
+            "WIFI 状态", "热点信息", "WiFi 文件传输", "基本参数", "打印状态", "ESC 打印", "OTA 升级",
+            "WiFi 文件传输", "选择文件", "开始传输", "选择 OTA 文件", "开始 OTA 升级", "选择图片", "开始打印",
+            "连续", "间隙", "黑标", "普通", "双重", "灰阶", "图像压缩"
+        };
+        for (String label : labels) {
+            Assert.assertTrue("Missing label: " + label, source.contains(label));
+        }
+    }
+
+    @Test
+    public void controller_containsRequiredJavaEmapiSdkCalls() throws Exception {
+        String source = read("src/main/java/com/printer/psdk/examples/emapi/EmapiDemoController.java");
+        String[] calls = {
+            ".sleepShutdown()", ".printSelfTestPage()", ".setShutdownTime(minutes)", ".queryRfidUid()",
+            ".queryRfidCardInfo()", ".queryRfidPaperLength()", ".setRfidAuthFailureHandling(EmapiRfidAuthFailurePolicy.FORBID_PRINT)",
+            ".setWifiConfig(ssid, password)", ".queryWifiConnectionState()", ".queryWifiHotspotInfo()",
+            ".queryDeviceInfo()", ".queryPrintStatus()", ".startWifiFileDownload(fileType, bytes.length)",
+            ".transferWifiFileDownloadChunk(index, chunk)", ".finishWifiFileDownload()", ".startMainControllerOta(bytes.length)",
+            ".transferMainControllerOtaChunk(index, chunk)", ".finishMainControllerOta()", ".upgradeMainController()", ".printEsc(escBytes)",
+            ".readNextReport()"
+        };
+        for (String call : calls) {
+            Assert.assertTrue("Missing SDK call: " + call, source.contains(call));
+        }
+    }
+
+    private String read(String relativePath) throws Exception {
+        File file = new File(relativePath);
+        return new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+    }
+}

--- a/android-native-java/emapi-android-demo/build.gradle
+++ b/android-native-java/emapi-android-demo/build.gradle
@@ -1,0 +1,14 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+        maven { url 'https://gitlab.com/api/v4/projects/35052067/packages/maven' }
+    }
+    dependencies {
+        classpath "com.android.tools.build:gradle:7.0.0"
+    }
+}
+
+task clean(type: Delete) {
+    delete rootProject.buildDir
+}

--- a/android-native-java/emapi-android-demo/gradle.properties
+++ b/android-native-java/emapi-android-demo/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+android.useAndroidX=true
+android.enableJetifier=true
+android.injected.testOnly=false

--- a/android-native-java/emapi-android-demo/gradlew
+++ b/android-native-java/emapi-android-demo/gradlew
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+set -eu
+
+DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+exec sh "$DIR/../generic-ge886-classic-buletooth-demo/gradlew" -p "$DIR" "$@"

--- a/android-native-java/emapi-android-demo/settings.gradle
+++ b/android-native-java/emapi-android-demo/settings.gradle
@@ -1,0 +1,11 @@
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        jcenter()
+        maven { url 'https://gitlab.com/api/v4/projects/35052067/packages/maven' }
+    }
+}
+rootProject.name = "emapi-android-demo"
+include ':app'


### PR DESCRIPTION
## Summary
Add a native Java Android EMAPI demo matching the Flutter EMAPI flow.

## Why
- Issue: [AYN-102](https://plane.kahub.in/endless/browse/AYN-102/)

## Changes
- Create android-native-java/emapi-android-demo with a native Java Activity shell, scan/settings/function screens, operation forms, and log tabs.
- Add an EMAPI controller using Java EMAPI SDK call boundaries for command queries, WiFi config, WiFi file transfer, OTA, ESC print, report reading, and simulation mode.
- Include Bluetooth connection tracing, byte display helpers, an isolated ESC command builder placeholder, and contract tests for UI labels and SDK call coverage.

## Impact
- android-native-java/emapi-android-demo/app/build.gradle
- android-native-java/emapi-android-demo/app/proguard-rules.pro
- android-native-java/emapi-android-demo/app/src/main/AndroidManifest.xml
- android-native-java/emapi-android-demo/app/src/main/java/com/printer/psdk/examples/emapi/BluetoothEmapiConnection.java
- android-native-java/emapi-android-demo/app/src/main/java/com/printer/psdk/examples/emapi/DeviceModel.java
- android-native-java/emapi-android-demo/app/src/main/java/com/printer/psdk/examples/emapi/EmapiDemoController.java
- android-native-java/emapi-android-demo/app/src/main/java/com/printer/psdk/examples/emapi/EscCommandBuilder.java
- android-native-java/emapi-android-demo/app/src/main/java/com/printer/psdk/examples/emapi/EscPrintOptions.java
- android-native-java/emapi-android-demo/app/src/main/java/com/printer/psdk/examples/emapi/Hex.java
- android-native-java/emapi-android-demo/app/src/main/java/com/printer/psdk/examples/emapi/LogEntry.java
- android-native-java/emapi-android-demo/app/src/main/java/com/printer/psdk/examples/emapi/MainActivity.java
- android-native-java/emapi-android-demo/app/src/main/java/com/printer/psdk/examples/emapi/TracingEmapiConnection.java
- android-native-java/emapi-android-demo/app/src/main/res/values/colors.xml
- android-native-java/emapi-android-demo/app/src/main/res/values/strings.xml
- android-native-java/emapi-android-demo/app/src/main/res/values/themes.xml
- android-native-java/emapi-android-demo/app/src/test/java/com/printer/psdk/examples/emapi/EmapiAndroidDemoContractTest.java
- android-native-java/emapi-android-demo/build.gradle
- android-native-java/emapi-android-demo/gradle.properties
- android-native-java/emapi-android-demo/gradlew
- android-native-java/emapi-android-demo/settings.gradle

## Verification
- `./gradlew assembleDebug` failed before project configuration because OpenJDK 26.0.1 is incompatible with the repo's Gradle 7.0.2/Groovy runtime (`Unsupported class file major version 70`).
- `./gradlew testDebugUnitTest` failed for the same OpenJDK 26.0.1 / Gradle 7.0.2 compatibility blocker before tests could run.
- Static `rg` checks confirmed required UI labels/forms and Java EMAPI SDK method sequences are present.

## Links
- Issue: [AYN-102](https://plane.kahub.in/endless/browse/AYN-102/)
- Related PR: https://github.com/prtmax/psdk-examples/pull/9
- metadata
  ```yaml
  schema: conductor/pr-body/1
  repository: psdk-examples
  issue: AYN-102
  issue_url: "https://plane.kahub.in/endless/browse/AYN-102/"
  run_id: run-ayn-102-1779865462750989071
  attempt_id: run-ayn-102-1779865462750989071-attempt-2
  head_branch: 0xfe10/feat/ayn-102-attempt-2
  base_branch: main
  commit_id: 83fb884e4c1e0830435a6b3c4a5d3308b7dff7f1
  metadata_attempt_id: run-ayn-102-1779865462750989071-attempt-2
  attempt_result_recorded: true
  related_prs:
    - "https://github.com/prtmax/psdk-examples/pull/9"
  ```